### PR TITLE
update react-map-gl to next minor version 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@material-ui/core": "^4.5.0",
+    "@material-ui/core": "^4.7.0",
     "@material-ui/icons": "^4.4.3",
     "axios": "^0.19.0",
     "dotenv": "^8.1.0",
@@ -22,7 +22,7 @@
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
     "react-i18next": "^10.13.1",
-    "react-map-gl": "^5.0.11",
+    "react-map-gl": "^5.1.3",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.1.2",
     "yup": "^0.27.0"

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@material-ui/core": "^4.7.0",
+    "@material-ui/core": "^4.6.1",
     "@material-ui/icons": "^4.4.3",
     "axios": "^0.19.0",
     "dotenv": "^8.1.0",


### PR DESCRIPTION
This fixes the GeolocateControl component from crashing the page. Nice knowing it was a bug in the dependency code and not mine!

See here for more details on the bug - https://github.com/uber/react-map-gl/issues/921