### PR TITLE
lucashomer -- fixing that pesky selectedCategories bug again :) 

### DIFF
--- a/client/src/components/StakeholderCriteria.js
+++ b/client/src/components/StakeholderCriteria.js
@@ -22,7 +22,7 @@ function StakeholderCriteria({
   openSearchPanel,
 }) {
   const classes = useStyles();
-
+  if (!selectedCategories) return null;
   return (
     <Card className={classes.card}>
       <CardContent>

--- a/client/src/hooks/useStakeholders/initialState.js
+++ b/client/src/hooks/useStakeholders/initialState.js
@@ -8,11 +8,6 @@ export const initialState = {
   categories: [],
   searchString: "",
   selectedCategories: null,
-  // [
-  //   { id: 1, name: "Food Pantry" },
-  //   { id: 8, name: "Food Bank" },
-  //   { id: 9, name: "Soup Kitchen" },
-  // ],
   latitude: null,
   longitude: null,
   selectedLatitude: 34.041001,

--- a/client/src/hooks/useStakeholders/initialState.js
+++ b/client/src/hooks/useStakeholders/initialState.js
@@ -1,5 +1,5 @@
 export const initialState = {
-  isLoading: true,
+  isLoading: false,
   categoriesError: null,
   stakeholdersError: null,
   locationError: null,
@@ -7,15 +7,16 @@ export const initialState = {
   stakeholders: [],
   categories: [],
   searchString: "",
-  selectedCategories: [
-    { id: 1, name: "Food Pantry" },
-    { id: 8, name: "Food Bank" },
-    { id: 9, name: "Soup Kitchen" }
-  ],
+  selectedCategories: null,
+  // [
+  //   { id: 1, name: "Food Pantry" },
+  //   { id: 8, name: "Food Bank" },
+  //   { id: 9, name: "Soup Kitchen" },
+  // ],
   latitude: null,
   longitude: null,
   selectedLatitude: 34.041001,
   selectedLongitude: -118.235036,
   selectedLocationName: "LACI",
-  selectedDistance: 10
+  selectedDistance: 10,
 };

--- a/client/src/hooks/useStakeholders/useStakeholders.js
+++ b/client/src/hooks/useStakeholders/useStakeholders.js
@@ -108,32 +108,35 @@ export function useStakeholders() {
   };
 
   useEffect(() => {
-    const {
-      searchString,
-      selectedLatitude,
-      selectedLongitude,
-      selectedLocationName,
-      selectedDistance,
-      selectedCategories,
-    } = initialState;
-
     // Runs once on initialization to get list of all active categories
     fetchCategories();
 
     // Runs once on initialization to get user's browser lat/lon, if
     // browser permits
     fetchLocation();
+  }, []);
 
-    // Exposed to consuming component to execute search
+  useEffect(() => {
+    // if we don't have the categories fetched yet, bail
+    if (!state.selectedCategories) return;
+
+    const {
+      searchString,
+      selectedLatitude,
+      selectedLongitude,
+      selectedLocationName,
+      selectedDistance,
+    } = initialState;
+
     search(
       searchString,
       selectedLatitude,
       selectedLongitude,
       selectedLocationName,
-      selectedCategories,
+      state.selectedCategories,
       selectedDistance,
     );
-  }, []);
+  }, [state.selectedCategories]);
 
   return { state, dispatch, actionTypes, search };
 }


### PR DESCRIPTION
I separated the initial `search()` into its own `useEffect()` so that it's only watching the state of `selectedCategories` so it knows as soon as we have our categories data from the fetch, and we've set the `selectedCategories` state with the appropriate default values, we can go ahead with the initial `search()`. Outside of generally being more in line with React's guidelines to keep useEffects related to only one data "thing," this also fixes the bug that likes to keep popping up where we can't deselect the initial selectedCategories values. 