### PR TITLE
fix bug in the "inactive" checkbox input

### DIFF
--- a/client/src/components/StakeholderEdit.js
+++ b/client/src/components/StakeholderEdit.js
@@ -640,9 +640,11 @@ const StakeholderEdit = props => {
                         margin="normal"
                         name="inactive"
                         label="Inactive"
-                        value="1"
+                        value={values.inactive}
                         checked={values.inactive}
-                        onChange={handleChange}
+                        onChange={() =>
+                          setFieldValue("inactive", !values.inactive)
+                        }
                         onBlur={handleBlur}
                       />
                     }


### PR DESCRIPTION
We needed to use the `setFieldValue` formik function rather than the more generic `handleChange`. I found this helpful -- https://stackoverflow.com/questions/57850970/checkbox-onchange-event-is-not-handled-by-handlechange-props-by-formik