### PR TITLE
Back-end hours validation

### DIFF
--- a/app/services/stakeholder-service.js
+++ b/app/services/stakeholder-service.js
@@ -684,8 +684,8 @@ const update = async (model) => {
     await pool.query(invokeSprocSql);
   } catch (e) {
     console.error(e);
-    // If this fails we probably shouldn't update anything
-    return;
+    // If this fails we don't update anything
+    return Promise.reject(e.message);
   }
 
   const sql = `


### PR DESCRIPTION
If there is any problem with the hours, the server will reject the web api call and an error message is shown to the user. The next step is good client-side hours validation...