### PR TITLE
cicd: adds action for build & pushing image on merge to develop;

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,24 @@
+# build and push a docker image from the latest push to "develop" branch
+on:
+  push:
+    - master
+    - develop
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    name: build image
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: build-and-push-image
+        uses: docker/build-push-action@v1
+        with:
+          usernmae: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: foodoasisla/foodoasisla
+          tag_with_ref: true
+          tag_with_sha: true
+          add_git_labels: true
+          labels: description="Food Oasis LA",maintained="foodoasis+hub@hackforla.org"
+


### PR DESCRIPTION
# summary
Adds an simple action for building and pushing the server application image to
docker hub at https://hub.docker.com/repository/docker/foodoasisla/foodoasisla

## pre-requisites
- [ ] enable a food oasis automation account on docker hub

- [ ] use its username and password in the "Settings" tab under "Secrets"
[see the instructions here on creating secrets on the github repo for use by an action](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)

create a secret called `DOCKER_USERNAME` with the value `foodoasis+automation@hackforla.org`

and another secret `DOCKER_PASSWORD` with the password

we'd need an admin to complete those two steps