### PR TITLE
adds jwt validation on stakeholder endpoints;

### DIFF
--- a/app/routes/stakeholder-router.js
+++ b/app/routes/stakeholder-router.js
@@ -1,15 +1,28 @@
 const router = require("express").Router();
 const stakeholderController = require("../controllers/stakeholder-controller");
+const jwtSession = require("../../middleware/jwt-session");
 
-router.get("/", stakeholderController.search);
-router.get("/dashboard", stakeholderController.searchDashboard);
-router.get("/:id", stakeholderController.getById);
-router.post("/csv", stakeholderController.csv);
-router.post("/", stakeholderController.post);
-router.put("/:id", stakeholderController.put);
-router.delete("/:id", stakeholderController.remove);
-router.put("/:id/needsVerification", stakeholderController.needsVerification);
-router.put("/:id/assign", stakeholderController.assign);
-router.put("/:id/claim", stakeholderController.claim);
+router.get("/", jwtSession.validateUser, stakeholderController.search);
+router.get(
+  "/dashboard",
+  jwtSession.validateUser,
+  stakeholderController.searchDashboard
+);
+router.get("/:id", jwtSession.validateUser, stakeholderController.getById);
+router.post("/csv", jwtSession.validateUser, stakeholderController.csv);
+router.post("/", jwtSession.validateUser, stakeholderController.post);
+router.put("/:id", jwtSession.validateUser, stakeholderController.put);
+router.delete("/:id", jwtSession.validateUser, stakeholderController.remove);
+router.put(
+  "/:id/needsVerification",
+  jwtSession.validateUser,
+  stakeholderController.needsVerification
+);
+router.put(
+  "/:id/assign",
+  jwtSession.validateUser,
+  stakeholderController.assign
+);
+router.put("/:id/claim", jwtSession.validateUser, stakeholderController.claim);
 
 module.exports = router;

--- a/middleware/jwt-session.js
+++ b/middleware/jwt-session.js
@@ -36,6 +36,7 @@ async function validateUser(req, res, next) {
 
   try {
     const payload = await verify(jwtString);
+    console.log("payload");
 
     if (payload.email) {
       req.user = payload;
@@ -44,7 +45,8 @@ async function validateUser(req, res, next) {
   } catch (err) {
     // 401 Unauthorize, indicating that user is not
     // authenticated.
-    res.status(401).send(err.message);
+    console.error("Authentication Error: ", err);
+    res.status(401).send({ status: "err", message: "Invalid Authentication" });
   }
 }
 


### PR DESCRIPTION
validate jwt before running stakeholder calls;
exits with 401 if jwt is invalid.

:warning: this is an example demonstrating adding the jwt validation on the API. I didn't test it on all routes :warning: 