### PR TITLE
ci: reenables build & push image action;

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,9 @@ on:
     branches:
       - master
       - develop
-
+  release:
+    types:
+      - published
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
enables github action to build and push a docker image of
food oasis backend application

Trigger build image when a new release is published