### PR TITLE
Fixed mobile keyboard not disappearing on redirect

### DIFF
--- a/client/src/components/Search.js
+++ b/client/src/components/Search.js
@@ -117,7 +117,7 @@ export default function Search(props) {
         placeholder="Search by address, neighborhood, or zip code"
         name="address"
         size="small"
-        autoFocus
+        autoFocus={false}
         InputProps={{
           classes: {
             input: classes.input,


### PR DESCRIPTION
- Keyboard would remain in mobile after redirect from home page. Fixed
by removing autoFocus from search TextField.

Fixes #652 