### PR TITLE
postgres image uses postgres/postgres user/pass for db user

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -23,10 +23,10 @@ $ docker-compose up db
    For example, with `psql` do:
 
 ```bash
-$ psql -U fola -d food -h localhost -p 5433 -W -f db/demo-db/foodoasis.sql
+$ psql -U postgres -d food -h localhost -p 5433 -W -f db/demo-db/foodoasis.sql
 ```
 
-You should be prompted for a password. Use `pgpass`.
+You should be prompted for a password. Use `postgres`.
 
 This should result in a successful import of the initial data and schema that
 are not tracked in the [migrations](./migrations) folder.


### PR DESCRIPTION
The default postgresql user for the postgres image is postgres/postgres.  Unless I'm missing something the fola user isn't created so trying to use it results in an error