### PR TITLE
add a list/map toggle for mobile view

### DIFF
--- a/client/src/components/ResultsContainer.js
+++ b/client/src/components/ResultsContainer.js
@@ -42,6 +42,9 @@ export default function ResultsContainer(props) {
   const [isMobile, changeMobile] = React.useState(
     mobileTest.test(navigator.userAgent) ? true : false
   );
+  const [isMapView, setIsMapView] = React.useState(true);
+
+  const switchResultsView = () => setIsMapView(!isMapView);
 
   React.useEffect(() => {
     const sortOrganizations = (a, b) => {
@@ -161,34 +164,41 @@ export default function ResultsContainer(props) {
         setIsPopupOpen={setIsPopupOpen}
         doSelectStakeholder={doSelectStakeholder}
         viewPortHash={viewPortHash}
+        isMobile={isMobile}
+        isMapView={isMapView}
+        switchResultsView={switchResultsView}
       />
       <Grid item container spacing={0} className={classes.listMapContainer}>
-        <ResultsList
-          selectedStakeholder={selectedStakeholder}
-          doSelectStakeholder={doSelectStakeholder}
-          stakeholders={sortedData}
-          setSelectedPopUp={setSelectedPopUp}
-          setIsPopupOpen={setIsPopupOpen}
-          isWindowWide={isWindowWide}
-          viewport={viewport}
-          setViewport={setViewport}
-          setToast={setToast}
-        />
-        <ResultsMap
-          selectedLatitude={initialCoords.latitude}
-          selectedLongitude={initialCoords.longitude}
-          viewport={viewport}
-          setViewport={setViewport}
-          stakeholders={data}
-          doSelectStakeholder={doSelectStakeholder}
-          categoryIds={categoryIds}
-          selectedPopUp={selectedPopUp}
-          setSelectedPopUp={setSelectedPopUp}
-          isPopupOpen={isPopupOpen}
-          setIsPopupOpen={setIsPopupOpen}
-          isWindowWide={isWindowWide}
-          isMobile={isMobile}
-        />
+        {(!isMobile || (isMobile && !isMapView)) && (
+          <ResultsList
+            selectedStakeholder={selectedStakeholder}
+            doSelectStakeholder={doSelectStakeholder}
+            stakeholders={sortedData}
+            setSelectedPopUp={setSelectedPopUp}
+            setIsPopupOpen={setIsPopupOpen}
+            viewport={viewport}
+            setViewport={setViewport}
+            setToast={setToast}
+            isMobile={isMobile}
+          />
+        )}
+        {(!isMobile || (isMobile && isMapView)) && (
+          <ResultsMap
+            selectedLatitude={initialCoords.latitude}
+            selectedLongitude={initialCoords.longitude}
+            viewport={viewport}
+            setViewport={setViewport}
+            stakeholders={data}
+            doSelectStakeholder={doSelectStakeholder}
+            categoryIds={categoryIds}
+            selectedPopUp={selectedPopUp}
+            setSelectedPopUp={setSelectedPopUp}
+            isPopupOpen={isPopupOpen}
+            setIsPopupOpen={setIsPopupOpen}
+            isWindowWide={isWindowWide}
+            isMobile={isMobile}
+          />
+        )}
       </Grid>
     </>
   );

--- a/client/src/components/ResultsFilters.js
+++ b/client/src/components/ResultsFilters.js
@@ -16,6 +16,7 @@ import {
   FOOD_PANTRY_CATEGORY_ID,
   DEFAULT_CATEGORIES,
 } from "../constants/stakeholder";
+import SwitchViewsButton from "./SwitchViewsButton";
 
 const useStyles = makeStyles((theme) => ({
   filterGroup: {
@@ -47,7 +48,6 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("xs")]: {
       padding: ".6rem .6rem",
       margin: ".3rem",
-      marginTop: "1rem",
       fontSize: "max(.8vw,12px)",
       borderRadius: "5px !important",
     },
@@ -62,7 +62,6 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("xs")]: {
       padding: ".4rem",
       margin: ".3rem",
-      marginTop: "1rem",
     },
   },
   menuItems: {
@@ -117,6 +116,9 @@ const useStyles = makeStyles((theme) => ({
   },
   buttonHolder: {
     display: "flex",
+    [theme.breakpoints.down("xs")]: {
+      marginTop: "1rem",
+    },
   },
 }));
 
@@ -139,6 +141,9 @@ const ResultsFilters = ({
   categoryIds,
   toggleCategory,
   viewPortHash,
+  isMobile,
+  isMapView,
+  switchResultsView,
 }) => {
   const classes = useStyles();
 
@@ -329,6 +334,13 @@ const ResultsFilters = ({
           </Button>
         </Grid>
         <Grid item>
+          {isMobile && (
+            <SwitchViewsButton
+              isMapView={isMapView}
+              onClick={switchResultsView}
+              color="white"
+            />
+          )}
           {/* <Button
             className={classes.filterGroupButton}
             style={{

--- a/client/src/components/ResultsList.js
+++ b/client/src/components/ResultsList.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import SelectedStakeholderDisplay from "./ResultsSelectedStakeholder";
 import PropTypes from "prop-types";
 import moment from "moment";
@@ -14,9 +14,7 @@ import {
 } from "../constants/stakeholder";
 import { ORGANIZATION_COLORS, CLOSED_COLOR } from "../constants/map";
 
-const { useRef } = React;
-
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles((theme, props) => ({
   list: {
     textAlign: "center",
     fontSize: "12px",
@@ -26,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     },
     [theme.breakpoints.down("sm")]: {
       order: 1,
-      height: "30em",
+      height: (props) => (props.isMobile ? "100%" : "30em"),
     },
   },
   stakeholderArrayHolder: {
@@ -172,8 +170,9 @@ const ResultsList = ({
   viewport,
   setViewport,
   setToast,
+  isMobile,
 }) => {
-  const classes = useStyles();
+  const classes = useStyles({ isMobile });
 
   const handleStakeholderClick = (stakeholder) => {
     doSelectStakeholder(stakeholder);
@@ -303,6 +302,7 @@ ResultsList.propTypes = {
   selectedStakeholder: PropTypes.object,
   stakeholders: PropTypes.arrayOf(PropTypes.object),
   setToast: PropTypes.func,
+  isMobile: PropTypes.bool,
 };
 
 export default ResultsList;

--- a/client/src/components/ResultsMap.js
+++ b/client/src/components/ResultsMap.js
@@ -78,7 +78,7 @@ function Map({
       xs={12}
       md={8}
       className={classes.map}
-      style={{ height: isWindowWide ? "100%" : "50%" }}
+      style={{ height: isWindowWide || isMobile ? "100%" : "50%" }}
     >
       <ReactMapGL
         {...viewport}
@@ -136,6 +136,7 @@ Map.propTypes = {
   categoryIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   selectedLatitude: PropTypes.number.isRequired,
   selectedLongitude: PropTypes.number.isRequired,
+  isMobile: PropTypes.bool,
 };
 
 export default Map;

--- a/client/src/components/SwitchViewsButton.js
+++ b/client/src/components/SwitchViewsButton.js
@@ -3,9 +3,17 @@ import { Button } from "@material-ui/core";
 import MapIcon from "@material-ui/icons/Map";
 import FormatListBulletedIcon from "@material-ui/icons/FormatListBulleted";
 
-export default function SwitchViewsButton({ isMapView, onClick }) {
+export default function SwitchViewsButton({
+  isMapView,
+  onClick,
+  color = "primary",
+}) {
   return (
-    <Button onClick={onClick} title={`Go to ${isMapView ? "List" : "Map"}`}>
+    <Button
+      onClick={onClick}
+      title={`Go to ${isMapView ? "List" : "Map"}`}
+      style={{ color }}
+    >
       {isMapView && (
         <>
           <span style={{ fontSize: "1rem", marginRight: ".5rem" }}>List</span>


### PR DESCRIPTION
Fixes #677

Uses the existing `isMobile` variable to then show only the map or list view and then add a toggle in the results filter to switch between the two.

<img width="434" alt="Screen Shot 2020-09-23 at 5 35 45 PM" src="https://user-images.githubusercontent.com/4600967/94076663-381b8880-fdc3-11ea-8b0c-a5bb06b10311.png">