### PR TITLE
Show location preview on mobile map view

### DIFF
--- a/client/src/components/MarkerPopup.js
+++ b/client/src/components/MarkerPopup.js
@@ -55,7 +55,7 @@ function MarkerPopup({ entity, handleClose }) {
       longitude={longitude}
       closeButton={true}
       closeOnClick={false}
-      onClose={() => handleClose(false)}
+      onClose={handleClose}
       dynamicPosition={true}
       anchor="top-left"
     >

--- a/client/src/components/ResultsContainer.js
+++ b/client/src/components/ResultsContainer.js
@@ -204,6 +204,7 @@ export default function ResultsContainer(props) {
             categoryIds={categoryIds}
             isWindowWide={isWindowWide}
             isMobile={isMobile}
+            setToast={setToast}
           />
         )}
       </Grid>

--- a/client/src/components/ResultsContainer.js
+++ b/client/src/components/ResultsContainer.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 import { useOrganizations } from "../hooks/useOrganizations/useOrganizations";
@@ -29,66 +29,38 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ResultsContainer(props) {
+  // Component state
   const storage = window.sessionStorage;
   const { userCoordinates, userSearch, setToast } = props;
   const { data, search } = useOrganizations();
-  const [sortedData, setSortedData] = React.useState([]);
+  const [sortedData, setSortedData] = useState([]);
   const classes = useStyles();
 
   const windowSize = window.innerWidth > 960 ? true : false;
-  const [isWindowWide, changeWindow] = React.useState(windowSize);
+  const [isWindowWide, changeWindow] = useState(windowSize);
 
   const mobileTest = new RegExp("Mobi", "i");
-  const [isMobile, changeMobile] = React.useState(
+  const [isMobile, changeMobile] = useState(
     mobileTest.test(navigator.userAgent) ? true : false
   );
-  const [isMapView, setIsMapView] = React.useState(true);
+  const [selectedStakeholder, onSelectStakeholder] = useState(null);
+  const [isMapView, setIsMapView] = useState(true);
 
-  const switchResultsView = () => setIsMapView(!isMapView);
-
-  React.useEffect(() => {
-    const sortOrganizations = (a, b) => {
-      if (
-        (a.inactive || a.inactiveTemporary) &&
-        !b.inactive &&
-        !b.inactiveTemporary
-      ) {
-        return 1;
-      } else if (
-        !a.inactive &&
-        !a.inactiveTemporary &&
-        (b.inactive || b.inactiveTemporary)
-      ) {
-        return -1;
-      } else {
-        return a.distance < b.distance ? -1 : a.distance > b.distance ? 1 : 0;
-      }
-    };
-    if (!data) {
-      return;
+  const doSelectStakeholder = (stakeholder) => {
+    if (stakeholder) {
+      setViewport({
+        ...viewport,
+        latitude: stakeholder.latitude,
+        longitude: stakeholder.longitude,
+      });
     }
-    setSortedData(data.sort(sortOrganizations));
-  }, [data]);
+    onSelectStakeholder(stakeholder);
+  };
 
-  React.useEffect(() => {
-    const changeInputContainerWidth = () => {
-      window.innerWidth > 960 ? changeWindow(true) : changeWindow(false);
-      mobileTest.test(navigator.userAgent)
-        ? changeMobile(true)
-        : changeMobile(false);
-    };
-
-    window.addEventListener("resize", changeInputContainerWidth);
-
-    return () =>
-      window.removeEventListener("resize", changeInputContainerWidth);
-  }, [mobileTest]);
-
-  React.useEffect(() => {
-    return () => {
-      sessionStorage.clear();
-    };
-  }, []);
+  const switchResultsView = () => {
+    doSelectStakeholder();
+    setIsMapView(!isMapView);
+  };
 
   const initialCategories = storage.categoryIds
     ? JSON.parse(storage.categoryIds)
@@ -117,16 +89,13 @@ export default function ResultsContainer(props) {
       : -118.243328,
   };
 
-  const [radius, setRadius] = React.useState(
+  const [radius, setRadius] = useState(
     storage?.radius ? JSON.parse(storage.radius) : 5
   );
-  const [origin, setOrigin] = React.useState(initialCoords);
-  const [isVerifiedSelected, selectVerified] = React.useState(
+  const [origin, setOrigin] = useState(initialCoords);
+  const [isVerifiedSelected, selectVerified] = useState(
     storage?.verified ? JSON.parse(storage.verified) : false
   );
-  const [selectedStakeholder, doSelectStakeholder] = React.useState(null);
-  const [selectedPopUp, setSelectedPopUp] = React.useState(null);
-  const [isPopupOpen, setIsPopupOpen] = React.useState(false);
 
   const viewPortHash = {
     1: 13.5,
@@ -138,12 +107,58 @@ export default function ResultsContainer(props) {
     50: 8,
   };
 
-  const [viewport, setViewport] = React.useState({
+  const [viewport, setViewport] = useState({
     zoom: viewPortHash[radius],
     latitude: origin.latitude || JSON.parse(storage.origin).latitude,
     longitude: origin.longitude || JSON.parse(storage.origin).longitude,
     logoPosition: "top-left",
   });
+
+  // Component effects
+
+  useEffect(() => {
+    const sortOrganizations = (a, b) => {
+      if (
+        (a.inactive || a.inactiveTemporary) &&
+        !b.inactive &&
+        !b.inactiveTemporary
+      ) {
+        return 1;
+      } else if (
+        !a.inactive &&
+        !a.inactiveTemporary &&
+        (b.inactive || b.inactiveTemporary)
+      ) {
+        return -1;
+      } else {
+        return a.distance < b.distance ? -1 : a.distance > b.distance ? 1 : 0;
+      }
+    };
+    if (!data) {
+      return;
+    }
+    setSortedData(data.sort(sortOrganizations));
+  }, [data]);
+
+  useEffect(() => {
+    const changeInputContainerWidth = () => {
+      window.innerWidth > 960 ? changeWindow(true) : changeWindow(false);
+      mobileTest.test(navigator.userAgent)
+        ? changeMobile(true)
+        : changeMobile(false);
+    };
+
+    window.addEventListener("resize", changeInputContainerWidth);
+
+    return () =>
+      window.removeEventListener("resize", changeInputContainerWidth);
+  }, [mobileTest]);
+
+  useEffect(() => {
+    return () => {
+      sessionStorage.clear();
+    };
+  }, []);
 
   return (
     <>
@@ -161,7 +176,6 @@ export default function ResultsContainer(props) {
         isWindowWide={isWindowWide}
         viewport={viewport}
         setViewport={setViewport}
-        setIsPopupOpen={setIsPopupOpen}
         doSelectStakeholder={doSelectStakeholder}
         viewPortHash={viewPortHash}
         isMobile={isMobile}
@@ -174,10 +188,6 @@ export default function ResultsContainer(props) {
             selectedStakeholder={selectedStakeholder}
             doSelectStakeholder={doSelectStakeholder}
             stakeholders={sortedData}
-            setSelectedPopUp={setSelectedPopUp}
-            setIsPopupOpen={setIsPopupOpen}
-            viewport={viewport}
-            setViewport={setViewport}
             setToast={setToast}
             isMobile={isMobile}
           />
@@ -190,11 +200,8 @@ export default function ResultsContainer(props) {
             setViewport={setViewport}
             stakeholders={data}
             doSelectStakeholder={doSelectStakeholder}
+            selectedStakeholder={selectedStakeholder}
             categoryIds={categoryIds}
-            selectedPopUp={selectedPopUp}
-            setSelectedPopUp={setSelectedPopUp}
-            isPopupOpen={isPopupOpen}
-            setIsPopupOpen={setIsPopupOpen}
             isWindowWide={isWindowWide}
             isMobile={isMobile}
           />

--- a/client/src/components/ResultsFilters.js
+++ b/client/src/components/ResultsFilters.js
@@ -129,7 +129,6 @@ const ResultsFilters = ({
   isWindowWide,
   viewport,
   setViewport,
-  setIsPopupOpen,
   doSelectStakeholder,
   origin,
   setOrigin,
@@ -185,7 +184,6 @@ const ResultsFilters = ({
         latitude: origin.latitude,
         longitude: origin.longitude,
       });
-      setIsPopupOpen(false);
       doSelectStakeholder(null);
     },
     [
@@ -199,7 +197,6 @@ const ResultsFilters = ({
       categoryIds,
       isVerifiedSelected,
       setViewport,
-      setIsPopupOpen,
       doSelectStakeholder,
       viewPortHash,
     ]

--- a/client/src/components/ResultsList.js
+++ b/client/src/components/ResultsList.js
@@ -3,13 +3,6 @@ import StakeholderDetails from "./StakeholderDetails";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import pantryIcon from "../images/pantryIcon";
-import mealIcon from "../images/mealIcon";
-import splitPantryMealIcon from "../images/splitPantryMealIcon";
-import {
-  MEAL_PROGRAM_CATEGORY_ID,
-  FOOD_PANTRY_CATEGORY_ID,
-} from "../constants/stakeholder";
 import StakeholderPreview from "./StakeholderPreview";
 
 const useStyles = makeStyles((theme, props) => ({
@@ -17,6 +10,10 @@ const useStyles = makeStyles((theme, props) => ({
     textAlign: "center",
     fontSize: "12px",
     overflow: "scroll",
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
     [theme.breakpoints.up("md")]: {
       height: "100%",
     },
@@ -25,29 +22,7 @@ const useStyles = makeStyles((theme, props) => ({
       height: (props) => (props.isMobile ? "100%" : "30em"),
     },
   },
-  stakeholderArray: {
-    width: "100%",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-  },
 }));
-
-const iconReturn = (stakeholder) => {
-  let isClosed = false;
-  if (stakeholder.inactiveTemporary || stakeholder.inactive) isClosed = true;
-
-  return stakeholder.categories.some(
-    (category) => category.id === FOOD_PANTRY_CATEGORY_ID
-  ) &&
-    stakeholder.categories.some(
-      (category) => category.id === MEAL_PROGRAM_CATEGORY_ID
-    )
-    ? splitPantryMealIcon(isClosed)
-    : stakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID
-    ? pantryIcon(isClosed)
-    : mealIcon(isClosed);
-};
 
 const ResultsList = ({
   doSelectStakeholder,
@@ -67,28 +42,23 @@ const ResultsList = ({
 
   return (
     <Grid item xs={12} md={4} className={classes.list}>
-      <div className={classes.stakeholderArray}>
-        <div ref={listRef}></div>
-        {stakeholders &&
-        selectedStakeholder &&
-        !selectedStakeholder.inactive ? (
-          <StakeholderDetails
-            doSelectStakeholder={doSelectStakeholder}
-            selectedStakeholder={selectedStakeholder}
-            iconReturn={iconReturn}
-            setToast={setToast}
+      <div ref={listRef}></div>
+      {stakeholders && selectedStakeholder && !selectedStakeholder.inactive ? (
+        <StakeholderDetails
+          doSelectStakeholder={doSelectStakeholder}
+          selectedStakeholder={selectedStakeholder}
+          setToast={setToast}
+        />
+      ) : (
+        stakeholders.map((stakeholder) => (
+          <StakeholderPreview
+            inList
+            key={stakeholder.id}
+            stakeholder={stakeholder}
+            doSelectStakeholder={selectStakeholder}
           />
-        ) : (
-          stakeholders.map((stakeholder) => (
-            <StakeholderPreview
-              key={stakeholder.id}
-              stakeholder={stakeholder}
-              doSelectStakeholder={selectStakeholder}
-              iconReturn={iconReturn}
-            />
-          ))
-        )}
-      </div>
+        ))
+      )}
     </Grid>
   );
 };

--- a/client/src/components/ResultsList.js
+++ b/client/src/components/ResultsList.js
@@ -45,6 +45,7 @@ const ResultsList = ({
       <div ref={listRef}></div>
       {stakeholders && selectedStakeholder && !selectedStakeholder.inactive ? (
         <StakeholderDetails
+          inList
           doSelectStakeholder={doSelectStakeholder}
           selectedStakeholder={selectedStakeholder}
           setToast={setToast}

--- a/client/src/components/ResultsList.js
+++ b/client/src/components/ResultsList.js
@@ -1,8 +1,6 @@
 import React, { useRef } from "react";
-import SelectedStakeholderDisplay from "./ResultsSelectedStakeholder";
+import StakeholderDetails from "./StakeholderDetails";
 import PropTypes from "prop-types";
-import moment from "moment";
-import mapMarker from "../images/mapMarker";
 import { Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import pantryIcon from "../images/pantryIcon";
@@ -12,7 +10,7 @@ import {
   MEAL_PROGRAM_CATEGORY_ID,
   FOOD_PANTRY_CATEGORY_ID,
 } from "../constants/stakeholder";
-import { ORGANIZATION_COLORS, CLOSED_COLOR } from "../constants/map";
+import StakeholderPreview from "./StakeholderPreview";
 
 const useStyles = makeStyles((theme, props) => ({
   list: {
@@ -27,66 +25,11 @@ const useStyles = makeStyles((theme, props) => ({
       height: (props) => (props.isMobile ? "100%" : "30em"),
     },
   },
-  stakeholderArrayHolder: {
+  stakeholderArray: {
     width: "100%",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-  },
-  stakeholderHolder: {
-    width: "80%",
-    minHeight: "6em",
-    display: "inherit",
-    justifyContent: "space-between",
-    padding: "1em 0",
-    borderBottom: " .2em solid #f1f1f1",
-  },
-  imgHolder: {
-    display: "inherit",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  infoHolder: {
-    fontSize: "1.1em",
-    textAlign: "left",
-    width: "60%",
-    display: "inherit",
-    flexDirection: "column",
-    justifyContent: "space-between",
-  },
-  checkHolder: {
-    width: "10%",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "space-between",
-  },
-  labelHolder: {
-    width: "100%",
-    display: "flex",
-    flexDirection: "column",
-  },
-  closedLabel: {
-    color: "#545454",
-    alignSelf: "flex-end",
-    backgroundColor: "#E0E0E0",
-    padding: ".25em .5em",
-    borderRadius: "3px",
-  },
-  openIndicatorLabel: {
-    color: "#fff",
-    alignSelf: "flex-start",
-    backgroundColor: "#008000",
-    padding: ".25em",
-    borderRadius: "3px",
-    margin: ".25em 0",
-  },
-  closingSoonIndicatorLabel: {
-    color: "#fff",
-    alignSelf: "flex-start",
-    backgroundColor: "#CC3333",
-    padding: ".25em",
-    borderRadius: "3px",
-    margin: ".25em 0",
   },
 }));
 
@@ -106,193 +49,45 @@ const iconReturn = (stakeholder) => {
     : mealIcon(isClosed);
 };
 
-const isLastOccurrenceInMonth = (currentDay) => {
-  const currentMonth = currentDay.month();
-  if (currentDay.add(7, "days").month() !== currentMonth) {
-    return true;
-  }
-};
-
-const stakeholdersCurrentDaysHours = (stakeholder) => {
-  const currentDay = moment();
-  const currentDayOfWeek = currentDay.format("ddd");
-  const dayOccurrenceInMonth = Math.ceil(currentDay.date() / 7); // In tandum with currentDayOfWeek tells us which week the day falls
-  const currentTime = currentDay.format("HH:mm:ss");
-  const currentDaysHoursOfOperation = stakeholder?.hours.filter(
-    (todaysHours) => {
-      const hasHoursToday = currentDayOfWeek === todaysHours.day_of_week;
-      const stakeholderOpenTime = moment(todaysHours.open, "HH:mm:ss").format(
-        "HH:mm:ss"
-      );
-      const stakeholderClosingTime = moment(
-        todaysHours.close,
-        "HH:mm:ss"
-      ).format("HH:mm:ss");
-      const isOnlyOpenOnLastWeekOfMonth =
-        hasHoursToday &&
-        isLastOccurrenceInMonth(currentDay) &&
-        todaysHours.week_of_month === 5;
-      return (
-        hasHoursToday &&
-        currentTime >= stakeholderOpenTime &&
-        currentTime < stakeholderClosingTime &&
-        (todaysHours.week_of_month === 0 ||
-          dayOccurrenceInMonth === todaysHours.week_of_month ||
-          isOnlyOpenOnLastWeekOfMonth)
-      );
-    }
-  );
-  if (currentDaysHoursOfOperation?.length > 0) {
-    return currentDaysHoursOfOperation;
-  }
-};
-
-const calculateMinutesToClosing = (hours) => {
-  const currentTime = moment().format("HH:mm");
-  return moment(hours[0].close, "HH:mm").diff(
-    moment(currentTime, "HH:mm"),
-    "minutes"
-  );
-};
-
-const isAlmostClosed = (hours) => {
-  const minutesToCloseFlag = 60;
-  const minutesToClosing = calculateMinutesToClosing(hours);
-  return minutesToClosing <= minutesToCloseFlag;
-};
-
 const ResultsList = ({
   doSelectStakeholder,
   selectedStakeholder,
   stakeholders,
-  setSelectedPopUp,
-  setIsPopupOpen,
-  viewport,
-  setViewport,
   setToast,
   isMobile,
 }) => {
   const classes = useStyles({ isMobile });
 
-  const handleStakeholderClick = (stakeholder) => {
-    doSelectStakeholder(stakeholder);
-    setIsPopupOpen(true);
-    setSelectedPopUp(stakeholder);
-    setViewport({
-      ...viewport,
-      latitude: stakeholder.latitude,
-      longitude: stakeholder.longitude,
-    });
-  };
+  const listRef = useRef();
 
-  const displayStakeHolderRef = useRef();
+  const selectStakeholder = (stakeholder) => {
+    doSelectStakeholder(stakeholder);
+    if (!isMobile && !!listRef) listRef.current.scrollIntoView();
+  };
 
   return (
     <Grid item xs={12} md={4} className={classes.list}>
-      <div className={classes.stakeholderArrayHolder}>
-        <div ref={displayStakeHolderRef}></div>
+      <div className={classes.stakeholderArray}>
+        <div ref={listRef}></div>
         {stakeholders &&
         selectedStakeholder &&
         !selectedStakeholder.inactive ? (
-          <SelectedStakeholderDisplay
+          <StakeholderDetails
             doSelectStakeholder={doSelectStakeholder}
             selectedStakeholder={selectedStakeholder}
             iconReturn={iconReturn}
             setToast={setToast}
           />
-        ) : stakeholders ? (
-          stakeholders.map((stakeholder) => {
-            const stakeholderHours = stakeholdersCurrentDaysHours(stakeholder);
-            const isOpenFlag = !!stakeholderHours;
-            const isAlmostClosedFlag =
-              isOpenFlag && isAlmostClosed(stakeholderHours);
-            const minutesToClosing =
-              isAlmostClosedFlag && calculateMinutesToClosing(stakeholderHours);
-
-            return (
-              <div
-                className={classes.stakeholderHolder}
-                key={stakeholder.id}
-                onClick={() => {
-                  handleStakeholderClick(stakeholder);
-                  displayStakeHolderRef.current.scrollIntoView();
-                }}
-              >
-                <div className={classes.imgHolder}>
-                  {iconReturn(stakeholder)}
-                </div>
-                <div className={classes.infoHolder}>
-                  <span>{stakeholder.name}</span>
-                  <span>{stakeholder.address1}</span>
-                  <div>
-                    {stakeholder.city} {stakeholder.zip}
-                  </div>
-                  {stakeholder.categories.map((category) => (
-                    <em
-                      key={stakeholder.id + category.id}
-                      style={{
-                        alignSelf: "flex-start",
-                        color:
-                          stakeholder.inactiveTemporary || stakeholder.inactive
-                            ? CLOSED_COLOR
-                            : category.id === FOOD_PANTRY_CATEGORY_ID
-                            ? ORGANIZATION_COLORS[FOOD_PANTRY_CATEGORY_ID]
-                            : category.id === MEAL_PROGRAM_CATEGORY_ID
-                            ? ORGANIZATION_COLORS[MEAL_PROGRAM_CATEGORY_ID]
-                            : "#000",
-                      }}
-                    >
-                      {category.name}
-                    </em>
-                  ))}
-                  <div className={classes.labelHolder}>
-                    {stakeholder.inactiveTemporary || stakeholder.inactive ? (
-                      <em className={classes.closedLabel}>
-                        {stakeholder.inactiveTemporary
-                          ? "Temporarily Closed"
-                          : "Permanently Closed"}
-                      </em>
-                    ) : null}
-
-                    {isOpenFlag &&
-                    !(stakeholder.inactiveTemporary || stakeholder.inactive) ? (
-                      <em className={classes.openIndicatorLabel}>OPEN NOW</em>
-                    ) : null}
-
-                    {isAlmostClosedFlag &&
-                    !(stakeholder.inactiveTemporary || stakeholder.inactive) &&
-                    isAlmostClosedFlag ? (
-                      <em className={classes.closingSoonIndicatorLabel}>
-                        {`Closing in ${minutesToClosing} minutes`}
-                      </em>
-                    ) : null}
-                  </div>
-                </div>
-                <div className={classes.checkHolder}>
-                  {stakeholder.distance >= 10
-                    ? stakeholder.distance
-                        .toString()
-                        .substring(0, 3)
-                        .padEnd(4, "0")
-                    : stakeholder.distance.toString().substring(0, 3)}{" "}
-                  mi
-                  {mapMarker(
-                    stakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID &&
-                      stakeholder.categories[1] &&
-                      stakeholder.categories[1].id === MEAL_PROGRAM_CATEGORY_ID
-                      ? -1
-                      : stakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID
-                      ? 0
-                      : 1,
-                    stakeholder.inactiveTemporary || stakeholder.inactive
-                      ? true
-                      : false
-                  )}
-                </div>
-              </div>
-            );
-          })
-        ) : null}
+        ) : (
+          stakeholders.map((stakeholder) => (
+            <StakeholderPreview
+              key={stakeholder.id}
+              stakeholder={stakeholder}
+              doSelectStakeholder={selectStakeholder}
+              iconReturn={iconReturn}
+            />
+          ))
+        )}
       </div>
     </Grid>
   );
@@ -301,6 +96,7 @@ const ResultsList = ({
 ResultsList.propTypes = {
   selectedStakeholder: PropTypes.object,
   stakeholders: PropTypes.arrayOf(PropTypes.object),
+  doSelectStakeholder: PropTypes.func,
   setToast: PropTypes.func,
   isMobile: PropTypes.bool,
 };

--- a/client/src/components/ResultsMap.js
+++ b/client/src/components/ResultsMap.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import ReactMapGL, { NavigationControl } from "react-map-gl";
 import { Grid } from "@material-ui/core";
@@ -17,6 +17,7 @@ import {
   MEAL_PROGRAM_CATEGORY_ID,
 } from "../constants/stakeholder";
 import StakeholderPreview from "./StakeholderPreview";
+import StakeholderDetails from "./StakeholderDetails";
 
 const styles = {
   geolocate: {
@@ -56,20 +57,29 @@ function Map({
   isMobile,
   viewport,
   setViewport,
+  setToast,
 }) {
   const classes = useStyles();
   const categoryIdsOrDefault = categoryIds.length
     ? categoryIds
     : DEFAULT_CATEGORIES;
 
-  const handleMarkerClick = (clickedStakeholder) => {
-    doSelectStakeholder(clickedStakeholder);
-    // setViewport({
-    //   ...viewport,
-    //   latitude: clickedStakeholder.latitude,
-    //   longitude: clickedStakeholder.longitude,
-    // });
+  const [showDetails, setShowDetails] = useState(false);
+
+  const unselectStakeholder = () => {
+    setShowDetails(false);
+    doSelectStakeholder(null);
   };
+
+  if (showDetails && isMobile && selectedStakeholder) {
+    return (
+      <StakeholderDetails
+        doSelectStakeholder={unselectStakeholder}
+        selectedStakeholder={selectedStakeholder}
+        setToast={setToast}
+      />
+    );
+  }
 
   return (
     <>
@@ -120,7 +130,7 @@ function Map({
                     : ORGANIZATION_COLORS[FOOD_PANTRY_CATEGORY_ID];
                 return (
                   <Marker
-                    onClick={() => handleMarkerClick(stakeholder)}
+                    onClick={() => doSelectStakeholder(stakeholder)}
                     key={`marker-${index}`}
                     longitude={stakeholder.longitude}
                     latitude={stakeholder.latitude}
@@ -141,7 +151,13 @@ function Map({
         </ReactMapGL>
       </Grid>
       {!!selectedStakeholder && isMobile && (
-        <Grid item xs={12} md={8} className={classes.preview}>
+        <Grid
+          item
+          xs={12}
+          md={8}
+          className={classes.preview}
+          onClick={() => setShowDetails(true)}
+        >
           <StakeholderPreview
             doSelectStakeholder={doSelectStakeholder}
             stakeholder={selectedStakeholder}

--- a/client/src/components/ResultsMap.js
+++ b/client/src/components/ResultsMap.js
@@ -24,14 +24,19 @@ const styles = {
     left: 0,
     margin: 10,
   },
-  navigationControl: { position: "absolute", top: 0, right: 0, margin: 10 },
+  navigationControl: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    margin: 10,
+    zIndex: 5,
+  },
 };
 
 const useStyles = makeStyles((theme) => ({
   map: {
     textAlign: "center",
     fontSize: "12px",
-    // height: "100%",
     [theme.breakpoints.down("sm")]: {
       order: 0,
     },
@@ -42,10 +47,7 @@ function Map({
   stakeholders,
   categoryIds,
   doSelectStakeholder,
-  selectedPopUp,
-  setSelectedPopUp,
-  isPopupOpen,
-  setIsPopupOpen,
+  selectedStakeholder,
   isWindowWide,
   isMobile,
   viewport,
@@ -57,19 +59,12 @@ function Map({
     : DEFAULT_CATEGORIES;
 
   const handleMarkerClick = (clickedStakeholder) => {
-    setSelectedPopUp(clickedStakeholder);
-    setIsPopupOpen(true);
     doSelectStakeholder(clickedStakeholder);
     // setViewport({
     //   ...viewport,
     //   latitude: clickedStakeholder.latitude,
     //   longitude: clickedStakeholder.longitude,
     // });
-  };
-
-  const handleClose = () => {
-    setIsPopupOpen(false);
-    setSelectedPopUp(null);
   };
 
   return (
@@ -123,8 +118,11 @@ function Map({
                 />
               );
             })}
-        {isPopupOpen && selectedPopUp && (
-          <MarkerPopup entity={selectedPopUp} handleClose={handleClose} />
+        {!!selectedStakeholder && (
+          <MarkerPopup
+            entity={selectedStakeholder}
+            handleClose={doSelectStakeholder}
+          />
         )}
       </ReactMapGL>
     </Grid>

--- a/client/src/components/ResultsMap.js
+++ b/client/src/components/ResultsMap.js
@@ -16,6 +16,7 @@ import {
   FOOD_PANTRY_CATEGORY_ID,
   MEAL_PROGRAM_CATEGORY_ID,
 } from "../constants/stakeholder";
+import StakeholderPreview from "./StakeholderPreview";
 
 const styles = {
   geolocate: {
@@ -40,6 +41,9 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("sm")]: {
       order: 0,
     },
+  },
+  preview: {
+    margin: "0 1em",
   },
 }));
 
@@ -68,64 +72,83 @@ function Map({
   };
 
   return (
-    <Grid
-      item
-      xs={12}
-      md={8}
-      className={classes.map}
-      style={{ height: isWindowWide || isMobile ? "100%" : "50%" }}
-    >
-      <ReactMapGL
-        {...viewport}
-        /* dragPan={isWindowWide && isMobile ? false : true} */
-        // touchAction="pan-y pinch-zoom"
-        width="100%"
-        height="100%"
-        onViewportChange={(newViewport) => setViewport(newViewport)}
-        mapboxApiAccessToken={MAPBOX_TOKEN}
-        mapStyle={MAPBOX_STYLE}
+    <>
+      <Grid
+        item
+        xs={12}
+        md={8}
+        className={classes.map}
+        style={{
+          height:
+            isWindowWide || isMobile
+              ? isMobile && !!selectedStakeholder
+                ? `calc(100% - 130px)`
+                : "100%"
+              : "50%",
+        }}
       >
-        <div style={styles.navigationControl}>
-          <NavigationControl showCompass={false} />
-        </div>
-        {stakeholders &&
-          stakeholders
-            .filter((sh) => sh.latitude && sh.longitude)
-            .map((stakeholder, index) => {
-              const isVerified = stakeholder.verificationStatusId === 4;
+        <ReactMapGL
+          {...viewport}
+          /* dragPan={isWindowWide && isMobile ? false : true} */
+          // touchAction="pan-y pinch-zoom"
+          width="100%"
+          height="100%"
+          onViewportChange={(newViewport) => setViewport(newViewport)}
+          mapboxApiAccessToken={MAPBOX_TOKEN}
+          mapStyle={MAPBOX_STYLE}
+        >
+          <div style={styles.navigationControl}>
+            <NavigationControl showCompass={false} />
+          </div>
+          {stakeholders &&
+            stakeholders
+              .filter((sh) => sh.latitude && sh.longitude)
+              .map((stakeholder, index) => {
+                const isVerified = stakeholder.verificationStatusId === 4;
 
-              const categories = stakeholder.categories.filter(({ id }) => {
-                return categoryIdsOrDefault.includes(id);
-              });
+                const categories = stakeholder.categories.filter(({ id }) => {
+                  return categoryIdsOrDefault.includes(id);
+                });
 
-              const color =
-                stakeholder.inactiveTemporary || stakeholder.inactive
-                  ? CLOSED_COLOR
-                  : categories.find(({ id }) => id === MEAL_PROGRAM_CATEGORY_ID)
-                  ? ORGANIZATION_COLORS[MEAL_PROGRAM_CATEGORY_ID]
-                  : ORGANIZATION_COLORS[FOOD_PANTRY_CATEGORY_ID];
-              return (
-                <Marker
-                  onClick={() => handleMarkerClick(stakeholder)}
-                  key={`marker-${index}`}
-                  longitude={stakeholder.longitude}
-                  latitude={stakeholder.latitude}
-                  isVerified={isVerified}
-                  color={color}
-                  categories={stakeholder.categories}
-                  inactive={stakeholder.inactive}
-                  inactiveTemporary={stakeholder.inactiveTemporary}
-                />
-              );
-            })}
-        {!!selectedStakeholder && (
-          <MarkerPopup
-            entity={selectedStakeholder}
-            handleClose={doSelectStakeholder}
+                const color =
+                  stakeholder.inactiveTemporary || stakeholder.inactive
+                    ? CLOSED_COLOR
+                    : categories.find(
+                        ({ id }) => id === MEAL_PROGRAM_CATEGORY_ID
+                      )
+                    ? ORGANIZATION_COLORS[MEAL_PROGRAM_CATEGORY_ID]
+                    : ORGANIZATION_COLORS[FOOD_PANTRY_CATEGORY_ID];
+                return (
+                  <Marker
+                    onClick={() => handleMarkerClick(stakeholder)}
+                    key={`marker-${index}`}
+                    longitude={stakeholder.longitude}
+                    latitude={stakeholder.latitude}
+                    isVerified={isVerified}
+                    color={color}
+                    categories={stakeholder.categories}
+                    inactive={stakeholder.inactive}
+                    inactiveTemporary={stakeholder.inactiveTemporary}
+                  />
+                );
+              })}
+          {!!selectedStakeholder && (
+            <MarkerPopup
+              entity={selectedStakeholder}
+              handleClose={doSelectStakeholder}
+            />
+          )}
+        </ReactMapGL>
+      </Grid>
+      {!!selectedStakeholder && isMobile && (
+        <Grid item xs={12} md={8} className={classes.preview}>
+          <StakeholderPreview
+            doSelectStakeholder={doSelectStakeholder}
+            stakeholder={selectedStakeholder}
           />
-        )}
-      </ReactMapGL>
-    </Grid>
+        </Grid>
+      )}
+    </>
   );
 }
 

--- a/client/src/components/StakeholderDetails.js
+++ b/client/src/components/StakeholderDetails.js
@@ -11,6 +11,7 @@ import {
 import { ORGANIZATION_COLORS, CLOSED_COLOR } from "../constants/map";
 import SuggestionDialog from "./SuggestionDialog";
 import { PlainButton } from "./Buttons";
+import getIcon from "../helpers/getIcon";
 
 const useStyles = makeStyles((theme) => ({
   stakeholderHolder: {
@@ -111,7 +112,6 @@ const useStyles = makeStyles((theme) => ({
 const StakeholderDetails = ({
   doSelectStakeholder,
   selectedStakeholder,
-  iconReturn,
   setToast,
 }) => {
   const classes = useStyles();
@@ -200,9 +200,7 @@ const StakeholderDetails = ({
         setToast={setToast}
       />
       <div className={classes.topInfoHolder}>
-        <div className={classes.imgHolder}>
-          {iconReturn(selectedStakeholder)}
-        </div>
+        <div className={classes.imgHolder}>{getIcon(selectedStakeholder)}</div>
         <div className={classes.infoHolder}>
           <span>{selectedStakeholder.name}</span>
           <span>{selectedStakeholder.address1}</span>

--- a/client/src/components/StakeholderDetails.js
+++ b/client/src/components/StakeholderDetails.js
@@ -108,7 +108,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const SelectedStakeholderDisplay = ({
+const StakeholderDetails = ({
   doSelectStakeholder,
   selectedStakeholder,
   iconReturn,
@@ -517,4 +517,4 @@ const SelectedStakeholderDisplay = ({
   );
 };
 
-export default SelectedStakeholderDisplay;
+export default StakeholderDetails;

--- a/client/src/components/StakeholderDetails.js
+++ b/client/src/components/StakeholderDetails.js
@@ -13,21 +13,21 @@ import SuggestionDialog from "./SuggestionDialog";
 import { PlainButton } from "./Buttons";
 import getIcon from "../helpers/getIcon";
 
-const useStyles = makeStyles((theme) => ({
-  stakeholderHolder: {
-    width: "80%",
-    display: "inherit",
-    flexDirection: "inherit",
+const useStyles = makeStyles((theme, props) => ({
+  stakeholder: {
+    width: (props) => (props.inList ? "80%" : "100%"),
+    display: "flex",
+    flexDirection: "column",
     justifyContent: "space-between",
-    padding: "1em 0",
+    padding: (props) => (props.inList ? "1em 0" : "1em"),
     alignItems: "center",
   },
-  topInfoHolder: {
+  topInfo: {
     width: "100%",
     display: "inherit",
     justifyContent: "inherit",
   },
-  imgHolder: {
+  img: {
     display: "inherit",
     justifyContent: "center",
     alignItems: "center",
@@ -35,7 +35,7 @@ const useStyles = makeStyles((theme) => ({
   typeLogo: {
     width: "72px",
   },
-  infoHolder: {
+  info: {
     fontSize: "1.1em",
     textAlign: "left",
     width: "60%",
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
     justifyContent: "space-between",
   },
-  checkHolder: {
+  check: {
     width: "10%",
     display: "flex",
     flexDirection: "column",
@@ -83,7 +83,7 @@ const useStyles = makeStyles((theme) => ({
     alignSelf: "flex-start",
     textAlign: "left",
   },
-  iconHolder: {
+  icon: {
     display: "flex",
     alignSelf: "flex-start",
   },
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
     alignSelf: "flex-start",
     margin: "1em 0 0 0",
   },
-  labelHolder: {
+  label: {
     width: "100%",
     display: "flex",
     flexDirection: "column",
@@ -113,8 +113,9 @@ const StakeholderDetails = ({
   doSelectStakeholder,
   selectedStakeholder,
   setToast,
+  inList = false,
 }) => {
-  const classes = useStyles();
+  const classes = useStyles({ inList });
   const [SuggestionDialogOpen, setSuggestionDialogOpen] = useState(false);
 
   const handleSuggestionDialogOpen = async () => {
@@ -190,7 +191,7 @@ const StakeholderDetails = ({
   };
 
   return (
-    <div className={classes.stakeholderHolder}>
+    <div className={classes.stakeholder}>
       <SuggestionDialog
         id="assign-dialog"
         keepMounted
@@ -199,9 +200,9 @@ const StakeholderDetails = ({
         stakeholder={selectedStakeholder}
         setToast={setToast}
       />
-      <div className={classes.topInfoHolder}>
-        <div className={classes.imgHolder}>{getIcon(selectedStakeholder)}</div>
-        <div className={classes.infoHolder}>
+      <div className={classes.topInfo}>
+        <div className={classes.img}>{getIcon(selectedStakeholder)}</div>
+        <div className={classes.info}>
           <span>{selectedStakeholder.name}</span>
           <span>{selectedStakeholder.address1}</span>
           <div>
@@ -226,7 +227,7 @@ const StakeholderDetails = ({
               {category.name}
             </em>
           ))}
-          <div className={classes.labelHolder}>
+          <div className={classes.label}>
             {selectedStakeholder.inactiveTemporary ||
             selectedStakeholder.inactive ? (
               <em className={classes.closedLabel}>
@@ -237,7 +238,7 @@ const StakeholderDetails = ({
             ) : null}
           </div>
         </div>
-        <div className={classes.checkHolder}>
+        <div className={classes.check}>
           {selectedStakeholder.distance >= 10
             ? selectedStakeholder.distance
                 .toString()
@@ -452,7 +453,7 @@ const StakeholderDetails = ({
       {selectedStakeholder.facebook || selectedStakeholder.instagram ? (
         <React.Fragment>
           <h2 className={classes.title}>Social Media</h2>
-          <div className={classes.iconHolder}>
+          <div className={classes.icon}>
             {selectedStakeholder.facebook ? (
               <a
                 className={classes.icons}

--- a/client/src/components/StakeholderPreview.js
+++ b/client/src/components/StakeholderPreview.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles((props) => ({
   stakeholder: {
     width: (props) => (props.inList ? "80%" : "100%"),
     minHeight: "6em",
-    display: (props) => (props.inList ? "inherit" : "flex"),
+    display: "flex",
     justifyContent: "space-between",
     alignItems: (props) => (props.inList ? "center" : "flex-start"),
     padding: "1em 0",

--- a/client/src/components/StakeholderPreview.js
+++ b/client/src/components/StakeholderPreview.js
@@ -8,15 +8,17 @@ import {
   FOOD_PANTRY_CATEGORY_ID,
 } from "../constants/stakeholder";
 import { ORGANIZATION_COLORS, CLOSED_COLOR } from "../constants/map";
+import getIcon from "../helpers/getIcon";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((props) => ({
   stakeholder: {
-    width: "80%",
+    width: (props) => (props.inList ? "80%" : "100%"),
     minHeight: "6em",
-    display: "inherit",
+    display: (props) => (props.inList ? "inherit" : "flex"),
     justifyContent: "space-between",
+    alignItems: (props) => (props.inList ? "center" : "flex-start"),
     padding: "1em 0",
-    borderBottom: " .2em solid #f1f1f1",
+    borderBottom: (props) => (props.inList ? " .2em solid #f1f1f1" : "none"),
   },
   img: {
     display: "inherit",
@@ -24,7 +26,7 @@ const useStyles = makeStyles(() => ({
     alignItems: "center",
   },
   info: {
-    fontSize: "1.1em",
+    fontSize: "1em",
     textAlign: "left",
     width: "60%",
     display: "inherit",
@@ -125,9 +127,9 @@ const isAlmostClosed = (hours) => {
 const StakeholderPreview = ({
   stakeholder,
   doSelectStakeholder,
-  iconReturn,
+  inList = false,
 }) => {
-  const classes = useStyles();
+  const classes = useStyles({ inList });
 
   const stakeholderHours = stakeholdersCurrentDaysHours(stakeholder);
   const isOpenFlag = !!stakeholderHours;
@@ -141,7 +143,7 @@ const StakeholderPreview = ({
       key={stakeholder.id}
       onClick={() => doSelectStakeholder(stakeholder)}
     >
-      <div className={classes.img}>{iconReturn(stakeholder)}</div>
+      <div className={classes.img}>{getIcon(stakeholder)}</div>
       <div className={classes.info}>
         <span>{stakeholder.name}</span>
         <span>{stakeholder.address1}</span>
@@ -212,7 +214,7 @@ const StakeholderPreview = ({
 StakeholderPreview.propTypes = {
   stakeholder: PropTypes.object.isRequired,
   doSelectStakeholder: PropTypes.func.isRequired,
-  iconReturn: PropTypes.func.isRequired,
+  inList: PropTypes.bool,
 };
 
 export default StakeholderPreview;

--- a/client/src/components/StakeholderPreview.js
+++ b/client/src/components/StakeholderPreview.js
@@ -1,0 +1,218 @@
+import React from "react";
+import PropTypes from "prop-types";
+import moment from "moment";
+import mapMarker from "../images/mapMarker";
+import { makeStyles } from "@material-ui/core/styles";
+import {
+  MEAL_PROGRAM_CATEGORY_ID,
+  FOOD_PANTRY_CATEGORY_ID,
+} from "../constants/stakeholder";
+import { ORGANIZATION_COLORS, CLOSED_COLOR } from "../constants/map";
+
+const useStyles = makeStyles(() => ({
+  stakeholder: {
+    width: "80%",
+    minHeight: "6em",
+    display: "inherit",
+    justifyContent: "space-between",
+    padding: "1em 0",
+    borderBottom: " .2em solid #f1f1f1",
+  },
+  img: {
+    display: "inherit",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  info: {
+    fontSize: "1.1em",
+    textAlign: "left",
+    width: "60%",
+    display: "inherit",
+    flexDirection: "column",
+    justifyContent: "space-between",
+  },
+  check: {
+    width: "10%",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+  },
+  label: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+  },
+  closedLabel: {
+    color: "#545454",
+    alignSelf: "flex-end",
+    backgroundColor: "#E0E0E0",
+    padding: ".25em .5em",
+    borderRadius: "3px",
+  },
+  openLabel: {
+    color: "#fff",
+    alignSelf: "flex-start",
+    backgroundColor: "#008000",
+    padding: ".25em",
+    borderRadius: "3px",
+    margin: ".25em 0",
+  },
+  closingSoonLabel: {
+    color: "#fff",
+    alignSelf: "flex-start",
+    backgroundColor: "#CC3333",
+    padding: ".25em",
+    borderRadius: "3px",
+    margin: ".25em 0",
+  },
+}));
+
+const isLastOccurrenceInMonth = (currentDay) => {
+  const currentMonth = currentDay.month();
+  if (currentDay.add(7, "days").month() !== currentMonth) {
+    return true;
+  }
+};
+
+const stakeholdersCurrentDaysHours = (stakeholder) => {
+  const currentDay = moment();
+  const currentDayOfWeek = currentDay.format("ddd");
+  const dayOccurrenceInMonth = Math.ceil(currentDay.date() / 7); // In tandum with currentDayOfWeek tells us which week the day falls
+  const currentTime = currentDay.format("HH:mm:ss");
+  const currentDaysHoursOfOperation = stakeholder?.hours.filter(
+    (todaysHours) => {
+      const hasHoursToday = currentDayOfWeek === todaysHours.day_of_week;
+      const stakeholderOpenTime = moment(todaysHours.open, "HH:mm:ss").format(
+        "HH:mm:ss"
+      );
+      const stakeholderClosingTime = moment(
+        todaysHours.close,
+        "HH:mm:ss"
+      ).format("HH:mm:ss");
+      const isOnlyOpenOnLastWeekOfMonth =
+        hasHoursToday &&
+        isLastOccurrenceInMonth(currentDay) &&
+        todaysHours.week_of_month === 5;
+      return (
+        hasHoursToday &&
+        currentTime >= stakeholderOpenTime &&
+        currentTime < stakeholderClosingTime &&
+        (todaysHours.week_of_month === 0 ||
+          dayOccurrenceInMonth === todaysHours.week_of_month ||
+          isOnlyOpenOnLastWeekOfMonth)
+      );
+    }
+  );
+  if (currentDaysHoursOfOperation?.length > 0) {
+    return currentDaysHoursOfOperation;
+  }
+};
+
+const calculateMinutesToClosing = (hours) => {
+  const currentTime = moment().format("HH:mm");
+  return moment(hours[0].close, "HH:mm").diff(
+    moment(currentTime, "HH:mm"),
+    "minutes"
+  );
+};
+
+const isAlmostClosed = (hours) => {
+  const minutesToCloseFlag = 60;
+  const minutesToClosing = calculateMinutesToClosing(hours);
+  return minutesToClosing <= minutesToCloseFlag;
+};
+
+const StakeholderPreview = ({
+  stakeholder,
+  doSelectStakeholder,
+  iconReturn,
+}) => {
+  const classes = useStyles();
+
+  const stakeholderHours = stakeholdersCurrentDaysHours(stakeholder);
+  const isOpenFlag = !!stakeholderHours;
+  const isAlmostClosedFlag = isOpenFlag && isAlmostClosed(stakeholderHours);
+  const minutesToClosing =
+    isAlmostClosedFlag && calculateMinutesToClosing(stakeholderHours);
+
+  return (
+    <div
+      className={classes.stakeholder}
+      key={stakeholder.id}
+      onClick={() => doSelectStakeholder(stakeholder)}
+    >
+      <div className={classes.img}>{iconReturn(stakeholder)}</div>
+      <div className={classes.info}>
+        <span>{stakeholder.name}</span>
+        <span>{stakeholder.address1}</span>
+        <div>
+          {stakeholder.city} {stakeholder.zip}
+        </div>
+        {stakeholder.categories.map((category) => (
+          <em
+            key={stakeholder.id + category.id}
+            style={{
+              alignSelf: "flex-start",
+              color:
+                stakeholder.inactiveTemporary || stakeholder.inactive
+                  ? CLOSED_COLOR
+                  : category.id === FOOD_PANTRY_CATEGORY_ID
+                  ? ORGANIZATION_COLORS[FOOD_PANTRY_CATEGORY_ID]
+                  : category.id === MEAL_PROGRAM_CATEGORY_ID
+                  ? ORGANIZATION_COLORS[MEAL_PROGRAM_CATEGORY_ID]
+                  : "#000",
+            }}
+          >
+            {category.name}
+          </em>
+        ))}
+        <div className={classes.label}>
+          {stakeholder.inactiveTemporary || stakeholder.inactive ? (
+            <em className={classes.closedLabel}>
+              {stakeholder.inactiveTemporary
+                ? "Temporarily Closed"
+                : "Permanently Closed"}
+            </em>
+          ) : null}
+
+          {isOpenFlag &&
+          !(stakeholder.inactiveTemporary || stakeholder.inactive) ? (
+            <em className={classes.openLabel}>OPEN NOW</em>
+          ) : null}
+
+          {isAlmostClosedFlag &&
+          !(stakeholder.inactiveTemporary || stakeholder.inactive) &&
+          isAlmostClosedFlag ? (
+            <em className={classes.closingSoonLabel}>
+              {`Closing in ${minutesToClosing} minutes`}
+            </em>
+          ) : null}
+        </div>
+      </div>
+      <div className={classes.check}>
+        {stakeholder.distance >= 10
+          ? stakeholder.distance.toString().substring(0, 3).padEnd(4, "0")
+          : stakeholder.distance.toString().substring(0, 3)}{" "}
+        mi
+        {mapMarker(
+          stakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID &&
+            stakeholder.categories[1] &&
+            stakeholder.categories[1].id === MEAL_PROGRAM_CATEGORY_ID
+            ? -1
+            : stakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID
+            ? 0
+            : 1,
+          stakeholder.inactiveTemporary || stakeholder.inactive ? true : false
+        )}
+      </div>
+    </div>
+  );
+};
+
+StakeholderPreview.propTypes = {
+  stakeholder: PropTypes.object.isRequired,
+  doSelectStakeholder: PropTypes.func.isRequired,
+  iconReturn: PropTypes.func.isRequired,
+};
+
+export default StakeholderPreview;

--- a/client/src/helpers/getIcon.js
+++ b/client/src/helpers/getIcon.js
@@ -1,0 +1,25 @@
+import pantryIcon from "../images/pantryIcon";
+import mealIcon from "../images/mealIcon";
+import splitPantryMealIcon from "../images/splitPantryMealIcon";
+import {
+  MEAL_PROGRAM_CATEGORY_ID,
+  FOOD_PANTRY_CATEGORY_ID,
+} from "../constants/stakeholder";
+
+const getIcon = (stakeholder) => {
+  let isClosed = false;
+  if (stakeholder.inactiveTemporary || stakeholder.inactive) isClosed = true;
+
+  return stakeholder.categories.some(
+    (category) => category.id === FOOD_PANTRY_CATEGORY_ID
+  ) &&
+    stakeholder.categories.some(
+      (category) => category.id === MEAL_PROGRAM_CATEGORY_ID
+    )
+    ? splitPantryMealIcon(isClosed)
+    : stakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID
+    ? pantryIcon(isClosed)
+    : mealIcon(isClosed);
+};
+
+export default getIcon;


### PR DESCRIPTION
Fixes #704, #694, #702 

When clicking on a pin on mobile a preview displays on the bottom of the screen.
Clicking on that preview will expand to show details.
Clicking on the back button goes back to the map.
Also, toggling between list and map view will always show the list or map instead of details.

Other notes: Did a bit of code cleanup to reuse more data and make the code a bit more readable.

<img width="438" alt="Screen Shot 2020-09-25 at 2 26 02 PM" src="https://user-images.githubusercontent.com/4600967/94307945-5906e980-ff3b-11ea-9f84-23f11eb754e7.png">

Note: What design changes could we do to not waste so much screen space on smaller mobile devices?
<img width="394" alt="Screen Shot 2020-09-25 at 2 25 54 PM" src="https://user-images.githubusercontent.com/4600967/94307936-560bf900-ff3b-11ea-80e0-51a2c32ce9ff.png">
