### PR TITLE
Remove mapbox api tokens

### DIFF
--- a/client/src/hooks/useMapboxGeocoder.js
+++ b/client/src/hooks/useMapboxGeocoder.js
@@ -9,7 +9,7 @@ const losAngelesCountyLatLong = "-118.9517,33.6988,-117.6462,34.8233";
 const californiaLatLong = "-124.389, 32.4796, -114.1723, 42.072";
 
 const MAPBOX_TOKEN =
-  "pk.eyJ1IjoibHVjYXNob21lciIsImEiOiJjazFqcnRjcm0wNmZ1M2JwZXg2eDFzMXd3In0.yYpkKLrFCxF-qyBfZH1a8w";
+  "REPLACE_WITH_API_TOKEN"
 
 const initialState = {
   isLoading: false,

--- a/client/src/secrets.js
+++ b/client/src/secrets.js
@@ -1,2 +1,2 @@
 export const MAPBOX_TOKEN =
-  "pk.eyJ1IjoibHVjYXNob21lciIsImEiOiJjazFqcnRjcm0wNmZ1M2JwZXg2eDFzMXd3In0.yYpkKLrFCxF-qyBfZH1a8w";
+  "REPLACE_WITH_API_TOKEN"


### PR DESCRIPTION
I noticed the code in your repo has what I think are your mapbox API token keys.  Probably best not to have it in a publicly accessible repo.  Also, it might be best to revoke the old keys so someone else doesn't use up api quote or run up a bill on your account.