### PR TITLE
Separate Stakeholder and StakeholderBest query paths full-stack

### DIFF
--- a/app/controllers/stakeholder-best-controller.js
+++ b/app/controllers/stakeholder-best-controller.js
@@ -1,0 +1,43 @@
+const stakeholderService = require("../services/stakeholder-best-service");
+
+const search = (req, res) => {
+  let categoryIds = req.query.categoryIds;
+  if (!req.query.latitude || !req.query.longitude) {
+    res
+      .status(404)
+      .json("Bad request: needs latitude and longitude parameters");
+  }
+  if (!categoryIds) {
+    // If no filter, just use active categories.
+    categoryIds = ["1", "3", "8", "9", "10", "11", "12"];
+  } else if (typeof categoryIds == "string") {
+    categoryIds = [categoryIds];
+  }
+  const params = { ...req.query, categoryIds };
+  stakeholderService
+    .search(params)
+    .then((resp) => {
+      res.send(resp);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status("404").json({ error: err.toString() });
+    });
+};
+
+const getById = (req, res) => {
+  const { id } = req.params;
+  stakeholderService
+    .selectById(id)
+    .then((resp) => {
+      res.send(resp);
+    })
+    .catch((err) => {
+      res.status("500").json({ error: err.toString() });
+    });
+};
+
+module.exports = {
+  search,
+  getById,
+};

--- a/app/controllers/stakeholder-controller.js
+++ b/app/controllers/stakeholder-controller.js
@@ -3,31 +3,6 @@ const { Readable } = require("stream");
 const stringify = require("csv-stringify");
 
 const search = (req, res) => {
-  let categoryIds = req.query.categoryIds;
-  if (!req.query.latitude || !req.query.longitude) {
-    res
-      .status(404)
-      .json("Bad request: needs latitude and longitude parameters");
-  }
-  if (!categoryIds) {
-    // If no filter, just use active categories.
-    categoryIds = ["1", "3", "8", "9", "10", "11", "12"];
-  } else if (typeof categoryIds == "string") {
-    categoryIds = [categoryIds];
-  }
-  const params = { ...req.query, categoryIds };
-  stakeholderService
-    .search(params)
-    .then((resp) => {
-      res.send(resp);
-    })
-    .catch((err) => {
-      console.log(err);
-      res.status("404").json({ error: err.toString() });
-    });
-};
-
-const searchDashboard = (req, res) => {
   if (req.distance && (!req.latitude || !req.longitude)) {
     res
       .status(404)
@@ -42,7 +17,7 @@ const searchDashboard = (req, res) => {
   }
   const params = { ...req.query, categoryIds };
   stakeholderService
-    .searchDashboard(params)
+    .search(params)
     .then((resp) => {
       res.send(resp);
     })
@@ -210,9 +185,8 @@ const claim = (req, res) => {
 
 module.exports = {
   search,
-  searchDashboard,
-  csv,
   getById,
+  csv,
   post,
   put,
   remove,

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -8,6 +8,7 @@ const suggestionRouter = require("./suggestion-router");
 
 const faqRouter = require("./faq-router");
 const stakeholderRouter = require("./stakeholder-router");
+const stakeholderBestRouter = require("./stakeholder-best-router");
 const importRouter = require("./import-router");
 const loadRouter = require("./load-router");
 const esriRouter = require("./esri-router");
@@ -15,6 +16,7 @@ const esriRouter = require("./esri-router");
 module.exports = router;
 
 router.use("/api/stakeholders", stakeholderRouter);
+router.use("/api/stakeholderbests", stakeholderBestRouter);
 router.use("/api/tenants", tenantRouter);
 router.use("/api/accounts", accountRouter);
 router.use("/api/categories", categoryRouter);

--- a/app/routes/stakeholder-best-router.js
+++ b/app/routes/stakeholder-best-router.js
@@ -1,0 +1,7 @@
+const router = require("express").Router();
+const stakeholderBestController = require("../controllers/stakeholder-best-controller");
+
+router.get("/", stakeholderBestController.search);
+router.get("/:id", stakeholderBestController.getById);
+
+module.exports = router;

--- a/app/routes/stakeholder-router.js
+++ b/app/routes/stakeholder-router.js
@@ -2,15 +2,14 @@ const router = require("express").Router();
 const stakeholderController = require("../controllers/stakeholder-controller");
 const jwtSession = require("../../middleware/jwt-session");
 
-router.get("/", stakeholderController.search);
 router.get(
-  "/dashboard",
+  "/",
   jwtSession.validateUserHasRequiredRoles([
     "admin",
     "data_entry",
     "coordinator",
   ]),
-  stakeholderController.searchDashboard
+  stakeholderController.search
 );
 router.get(
   "/:id",

--- a/app/services/stakeholder-best-service.js
+++ b/app/services/stakeholder-best-service.js
@@ -1,0 +1,377 @@
+const { pool } = require("./postgres-pool");
+
+/* 
+
+This service is for getting data from the stakeholder_best table, which
+is what we want for the food seeker UI. It represents the "best" version of
+each stakeholder to show end users, which is either the last approved version
+(as indicated by is_verified = true) or if no version of the stakeholder
+record has been approved, it will be the most recent version (i.e., have
+  the same values as the stakeholder table for that id.)
+
+If you make changes to the database structure, be sure to update these
+methods as well as the corresponding methods in the stakeholder-service.js.
+
+*/
+
+const booleanEitherClause = (columnName, value) => {
+  return value === "true"
+    ? ` and ${columnName} is true `
+    : value === "false"
+    ? ` and ${columnName} is false `
+    : "";
+};
+
+const search = async ({
+  categoryIds,
+  latitude,
+  longitude,
+  distance,
+  isInactive,
+  verificationStatusId,
+  tenantId,
+}) => {
+  const locationClause = buildLocationClause(latitude, longitude);
+  const categoryClause = buildCTEClause(categoryIds, "");
+
+  const sql = `${categoryClause}
+    select s.id, s.name, s.address_1, s.address_2, s.city, s.state, s.zip,
+    s.phone, s.latitude, s.longitude, s.website,  s.notes,
+    to_char(s.created_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+      as created_date, s.created_login_id,
+    to_char(s.modified_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+      as modified_date, s.modified_login_id,
+    to_char(s.submitted_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+      as submitted_date, s.submitted_login_id,
+    to_char(s.approved_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+      as approved_date, s.reviewed_login_id,
+    to_char(s.assigned_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+      as assigned_date, s.assigned_login_id,
+    to_char(s.created_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+      as claimed_date, s.claimed_login_id,
+    s.requirements, s.admin_notes, s.inactive,
+    s.parent_organization, s.physical_access, s.email,
+    s.items, s.services, s.facebook,
+    s.twitter, s.pinterest, s.linkedin, s.description,
+    s.review_notes, s.instagram, s.admin_contact_name,
+    s.admin_contact_phone, s.admin_contact_email,
+    s.donation_contact_name, s.donation_contact_phone,
+    s.donation_contact_email, s.donation_pickup,
+    s.donation_accept_frozen, s.donation_accept_refrigerated,
+    s.donation_accept_perishable, s.donation_schedule,
+    s.donation_delivery_instructions, s.donation_notes, s.covid_notes,
+    s.category_notes, s.eligibility_notes, s.food_types, s.languages,
+    s.v_name, s.v_categories, s.v_address, s.v_phone, s.v_email,
+    s.v_hours, s.verification_status_id, s.inactive_temporary,
+    array_to_json(s.hours) as hours, s.category_ids,
+    s.neighborhood_id, s.is_verified,
+    ${locationClause ? `${locationClause} AS distance,` : ""}
+    ${buildLoginSelectsClause()}
+    from stakeholder_set as s
+    ${buildLoginJoinsClause()}
+    where s.tenant_id = ${tenantId} 
+    ${
+      Number(distance) && locationClause
+        ? `AND ${locationClause} < ${distance}`
+        : ""
+    }
+    ${booleanEitherClause("s.inactive", isInactive)}
+    ${
+      Number(verificationStatusId) > 0
+        ? ` and s.verification_status_id = ${verificationStatusId} `
+        : ""
+    }
+    order by distance
+  `;
+  // console.log(sql);
+  let stakeholders = [];
+  let categoriesResults = [];
+  var stakeholderResult, stakeholder_ids;
+  try {
+    stakeholderResult = await pool.query(sql);
+    stakeholder_ids = stakeholderResult.rows.map((a) => a.id);
+
+    if (stakeholder_ids.length) {
+      // Hoover up all the stakeholder categories
+      // for all of our stakeholder row results.
+      const categoriesSql = `select sc.stakeholder_id, c.id, c.name, c.display_order
+          from category c
+          join stakeholder_category sc on c.id = sc.category_id
+          where sc.stakeholder_id in (${stakeholder_ids.join(",")})
+          order by c.display_order, c.name`;
+      categoriesResults = await pool.query(categoriesSql);
+    }
+  } catch (err) {
+    return Promise.reject(err.message);
+  }
+
+  stakeholderResult.rows.forEach((row) => {
+    stakeholders.push({
+      id: row.id,
+      name: row.name || "",
+      address1: row.address_1 || "",
+      address2: row.address_2 || "",
+      city: row.city || "",
+      state: row.state || "",
+      zip: row.zip || "",
+      phone: row.phone || "",
+      latitude: row.latitude ? Number(row.latitude) : null,
+      longitude: row.longitude ? Number(row.longitude) : null,
+      distance: row.distance ? Number(row.distance) : null,
+      website: row.website || "",
+      notes: row.notes || "",
+      createdDate: row.created_date,
+      createdLoginId: row.created_login_id,
+      modifiedDate: row.modified_date,
+      modifiedLoginId: row.modified_login_id,
+      submittedDate: row.submitted_date,
+      submittedLoginId: row.submitted_login_id,
+      assignedDate: row.assigned_date,
+      assignedLoginId: row.assigned_login_id,
+      approvedDate: row.approved_date,
+      reviewedLoginId: row.reviewed_login_id,
+      claimedDate: row.claimed_date,
+      claimedLoginId: row.claimed_login_id,
+      requirements: row.requirements || "",
+      adminNotes: row.admin_notes || "",
+      inactive: row.inactive,
+      createdUser: row.created_user || "",
+      modifiedUser: row.modified_user || "",
+      submittedUser: row.submitted_user || "",
+      reviewedUser: row.reviewed_user || "",
+      assignedUser: row.assigned_user || "",
+      claimedUser: row.claimed_user || "",
+      categories: categoriesResults.rows.filter(
+        (cats) => cats.stakeholder_id == row.id
+      ),
+      hours: row.hours || [],
+      parentOrganization: row.parent_organization || "",
+      physicalAccess: row.physical_access || "",
+      email: row.email || "",
+      items: row.items || "",
+      services: row.services || "",
+      facebook: row.facebook || "",
+      twitter: row.twitter || "",
+      pinterest: row.pinterest || "",
+      linkedin: row.linkedin || "",
+      description: row.description,
+      reviewNotes: row.review_notes,
+      instagram: row.instagram || "",
+      adminContactName: row.admin_contact_name || "",
+      adminContactPhone: row.admin_contact_phone || "",
+      adminContactEmail: row.admin_contact_email || "",
+      donationContactName: row.donation_contact_name || "",
+      donationContactPhone: row.donation_contact_phone || "",
+      donationContactEmail: row.donation_contact_email || "",
+      donationPickup: row.donation_pickup || false,
+      donationAcceptFrozen: row.donation_accept_frozen || false,
+      donationAcceptRefrigerated: row.donation_accept_refrigerated || false,
+      donationAcceptPerishable: row.donation_accept_perishable || false,
+      donationSchedule: row.donation_schedule || "",
+      donationDeliveryInstructions: row.donation_delivery_instructions || "",
+      donationNotes: row.donation_notes || "",
+      covidNotes: row.covid_notes || "",
+      categoryNotes: row.category_notes || "",
+      eligibilityNotes: row.eligibility_notes || "",
+      foodTypes: row.food_types || "",
+      languages: row.languages || "",
+      confirmedName: row.v_name,
+      confirmedCategories: row.v_categories,
+      confirmedAddress: row.v_address,
+      confirmedPhone: row.v_phone,
+      confirmedEmail: row.v_email,
+      confirmedHours: row.v_hours,
+      verificationStatusId: row.verification_status_id,
+      inactiveTemporary: row.inactive_temporary,
+      neighborhoodId: row.neighborhood_id,
+      is_verified: row.is_verified,
+    });
+  });
+
+  return stakeholders;
+};
+
+const selectById = async (id) => {
+  const sql = `select
+      s.id, s.name, s.address_1, s.address_2, s.city, s.state, s.zip,
+      s.phone, s.latitude, s.longitude, s.website,  s.notes,
+      s.hours,
+      (select array(select row_to_json(category_row)
+        from (
+          select c.id, c.name, c.display_order
+          from category c
+            join stakeholder_best_category sc on c.id = sc.category_id
+          where sc.stakeholder_id = s.id
+          order by c.display_order
+        ) category_row
+      )) as categories,
+      to_char(s.created_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') as created_date, s.created_login_id,
+      to_char(s.modified_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') as modified_date, s.modified_login_id,
+      to_char(s.submitted_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') as submitted_date, s.submitted_login_id,
+      to_char(s.approved_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') as approved_date, s.reviewed_login_id,
+      to_char(s.assigned_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')as assigned_date, s.assigned_login_id,
+      to_char(s.created_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') as claimed_date, s.claimed_login_id,
+      s.requirements::varchar, s.admin_notes, s.inactive,
+      s.parent_organization, s.physical_access, s.email,
+      s.items, s.services, s.facebook,
+      s.twitter, s.pinterest, s.linkedin, s.description,
+      s.review_notes, s.instagram, s.admin_contact_name,
+      s.admin_contact_phone, s.admin_contact_email,
+      s.donation_contact_name, s.donation_contact_phone,
+      s.donation_contact_email, s.donation_pickup,
+      s.donation_accept_frozen, s.donation_accept_refrigerated,
+      s.donation_accept_perishable, s.donation_schedule,
+      s.donation_delivery_instructions, s.donation_notes, s.covid_notes,
+      s.category_notes, s.eligibility_notes, s.food_types, s.languages,
+      s.v_name, s.v_categories, s.v_address, s.v_phone, s.v_email,
+      s.v_hours, s.verification_status_id, s.inactive_temporary,
+      s.neighborhood_id, s.is_verified,
+      ${buildLoginSelectsClause()}
+    from stakeholder_best s
+    ${buildLoginJoinsClause()}
+    where s.id = ${id}`;
+  const result = await pool.query(sql);
+  const row = result.rows[0];
+  const stakeholder = {
+    id: row.id,
+    name: row.name || "",
+    address1: row.address_1 || "",
+    address2: row.address_2 || "",
+    city: row.city || "",
+    state: row.state || "",
+    zip: row.zip || "",
+    phone: row.phone || "",
+    latitude: row.latitude ? Number(row.latitude) : null,
+    longitude: row.longitude ? Number(row.longitude) : null,
+    website: row.website || "",
+    createdDate: row.created_date,
+    notes: row.notes || "",
+    createdLoginId: row.created_login_id,
+    modifiedDate: row.modified_date,
+    modifiedLoginId: row.modified_login_id,
+    submittedDate: row.submitted_date,
+    submittedLoginId: row.submitted_login_id,
+    approvedDate: row.approved_date,
+    reviewedLoginId: row.approved_login_id,
+    assignedLoginId: row.assigned_login_id,
+    assignedDate: row.assigned_date,
+    claimedLoginId: row.claimed_login_id,
+    claimedDate: row.claimed_date,
+    requirements: row.requirements || "",
+    adminNotes: row.admin_notes || "",
+    inactive: row.inactive,
+    createdUser: row.created_user || "",
+    modifiedUser: row.modified_user || "",
+    submittedUser: row.submitted_user || "",
+    reviewedUser: row.reviewed_user || "",
+    assignedUser: row.assigned_user || "",
+    claimedUser: row.claimed_user || "",
+    categories: row.categories,
+    hours: row.hours,
+    parentOrganization: row.parent_organization || "",
+    physicalAccess: row.physical_access || "",
+    email: row.email || "",
+    items: row.items || "",
+    services: row.services || "",
+    facebook: row.facebook || "",
+    twitter: row.twitter || "",
+    pinterest: row.pinterest || "",
+    linkedin: row.linkedin || "",
+    description: row.description,
+    reviewNotes: row.review_notes,
+    instagram: row.instagram || "",
+    adminContactName: row.admin_contact_name || "",
+    adminContactPhone: row.admin_contact_phone || "",
+    adminContactEmail: row.admin_contact_email || "",
+    donationContactName: row.donation_contact_name || "",
+    donationContactPhone: row.donation_contact_phone || "",
+    donationContactEmail: row.donation_contact_email || "",
+    donationPickup: row.donation_pickup || false,
+    donationAcceptFrozen: row.donation_accept_frozen || false,
+    donationAcceptRefrigerated: row.donation_accept_refrigerated || false,
+    donationAcceptPerishable: row.donation_accept_perishable || false,
+    donationSchedule: row.donation_schedule || "",
+    donationDeliveryInstructions: row.donation_delivery_instructions || "",
+    donationNotes: row.donation_notes || "",
+    covidNotes: row.covid_notes || "",
+    categoryNotes: row.category_notes || "",
+    eligibilityNotes: row.eligibility_notes || "",
+    foodTypes: row.food_types || "",
+    languages: row.languages || "",
+    confirmedName: row.v_name,
+    confirmedCategories: row.v_categories,
+    confirmedAddress: row.v_address,
+    confirmedPhone: row.v_phone,
+    confirmedEmail: row.v_email,
+    confirmedHours: row.v_hours,
+    verificationStatusId: row.verification_status_id,
+    inactiveTemporary: row.inactive_temporary,
+    neighborhoodId: row.neighborhood_id,
+    is_verified: row.is_verified,
+  };
+
+  // Don't have a distance, since we didn't specify origin
+  stakeholder.distance = null;
+
+  return stakeholder;
+};
+
+const buildCTEClause = (categoryIds, name) => {
+  const categoryClause = categoryIds
+    ? `stakeholder_category_set AS (
+       select * from stakeholder_best_category
+       where stakeholder_best_category.category_id in (${categoryIds.join(
+         ","
+       )})),`
+    : "";
+  const nameClause = "'%" + name.replace(/'/g, "''") + "%'";
+  const cteClause = `WITH ${categoryClause}
+  stakeholder_set AS (
+    select * from stakeholder_best
+    where name ilike ${nameClause}
+    and id in (
+      select stakeholder_id from stakeholder_category_set
+    )
+  )`;
+  return cteClause;
+};
+
+const buildLocationClause = (latitude, longitude) => {
+  var locationClause = "";
+  if (latitude && longitude) {
+    locationClause =
+      " point(" +
+      longitude +
+      ", " +
+      latitude +
+      ") <@> point(s.longitude, s.latitude) ";
+  }
+  return locationClause;
+};
+
+const buildLoginJoinsClause = () => {
+  return `
+    left join login L1 on s.created_login_id = L1.id
+    left join login L2 on s.modified_login_id = L2.id
+    left join login L3 on s.submitted_login_id = L3.id
+    left join login L4 on s.reviewed_login_id = L4.id
+    left join login L5 on s.assigned_login_id = L5.id
+    left join login L6 on s.claimed_login_id = L6.id
+  `;
+};
+
+const buildLoginSelectsClause = () => {
+  return `
+    concat(L1.first_name, ' ', L1.last_name) as created_user,
+    concat(L2.first_name, ' ', L2.last_name) as modified_user,
+    concat(L3.first_name, ' ', L3.last_name) as submitted_user,
+    concat(L4.first_name, ' ', L4.last_name) as reviewed_user,
+    concat(L5.first_name, ' ', L5.last_name) as assigned_user,
+    concat(L6.first_name, ' ', L6.last_name) as claimed_user
+  `;
+};
+
+module.exports = {
+  search,
+  selectById,
+};

--- a/app/services/stakeholder-service.js
+++ b/app/services/stakeholder-service.js
@@ -6,6 +6,18 @@ const {
   toSqlTimestamp,
 } = require("./postgres-utils");
 
+/* 
+
+This service is for getting data from the stakeholder table, which
+is what we want for the administration UI. It represents the most recent
+draft version of each stakeholder for data entry and administrators
+to work with.
+
+If you make changes to the database structure, be sure to update these
+methods as well as the corresponding methods in the stakeholder-best-service.js.
+
+*/
+
 const trueFalseEitherClause = (columnName, value) => {
   return value === "true"
     ? ` and ${columnName} is not null `
@@ -23,176 +35,6 @@ const booleanEitherClause = (columnName, value) => {
 };
 
 const search = async ({
-  categoryIds,
-  latitude,
-  longitude,
-  distance,
-  isInactive,
-  verificationStatusId,
-  tenantId,
-}) => {
-  const locationClause = buildLocationClause(latitude, longitude);
-  const categoryClause = buildCTEClause(categoryIds, "", true); // true indicates we want to search
-  // stakeholder_best table, not stakeholder
-
-  const sql = `${categoryClause}
-    select s.id, s.name, s.address_1, s.address_2, s.city, s.state, s.zip,
-    s.phone, s.latitude, s.longitude, s.website,  s.notes,
-    to_char(s.created_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
-      as created_date, s.created_login_id,
-    to_char(s.modified_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
-      as modified_date, s.modified_login_id,
-    to_char(s.submitted_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
-      as submitted_date, s.submitted_login_id,
-    to_char(s.approved_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
-      as approved_date, s.reviewed_login_id,
-    to_char(s.assigned_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
-      as assigned_date, s.assigned_login_id,
-    to_char(s.created_date at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
-      as claimed_date, s.claimed_login_id,
-    s.requirements, s.admin_notes, s.inactive,
-    s.parent_organization, s.physical_access, s.email,
-    s.items, s.services, s.facebook,
-    s.twitter, s.pinterest, s.linkedin, s.description,
-    s.review_notes, s.instagram, s.admin_contact_name,
-    s.admin_contact_phone, s.admin_contact_email,
-    s.donation_contact_name, s.donation_contact_phone,
-    s.donation_contact_email, s.donation_pickup,
-    s.donation_accept_frozen, s.donation_accept_refrigerated,
-    s.donation_accept_perishable, s.donation_schedule,
-    s.donation_delivery_instructions, s.donation_notes, s.covid_notes,
-    s.category_notes, s.eligibility_notes, s.food_types, s.languages,
-    s.v_name, s.v_categories, s.v_address, s.v_phone, s.v_email,
-    s.v_hours, s.verification_status_id, s.inactive_temporary,
-    array_to_json(s.hours) as hours, s.category_ids,
-    s.neighborhood_id, s.is_verified,
-    ${locationClause ? `${locationClause} AS distance,` : ""}
-    ${buildLoginSelectsClause()}
-    from stakeholder_set as s
-    ${buildLoginJoinsClause()}
-    where s.tenant_id = ${tenantId} 
-    ${
-      Number(distance) && locationClause
-        ? `AND ${locationClause} < ${distance}`
-        : ""
-    }
-    ${booleanEitherClause("s.inactive", isInactive)}
-    ${
-      Number(verificationStatusId) > 0
-        ? ` and s.verification_status_id = ${verificationStatusId} `
-        : ""
-    }
-    order by distance
-  `;
-  // console.log(sql);
-  let stakeholders = [];
-  let categoriesResults = [];
-  var stakeholderResult, stakeholder_ids;
-  try {
-    stakeholderResult = await pool.query(sql);
-    stakeholder_ids = stakeholderResult.rows.map((a) => a.id);
-
-    if (stakeholder_ids.length) {
-      // Hoover up all the stakeholder categories
-      // for all of our stakeholder row results.
-      const categoriesSql = `select sc.stakeholder_id, c.id, c.name, c.display_order
-          from category c
-          join stakeholder_category sc on c.id = sc.category_id
-          where sc.stakeholder_id in (${stakeholder_ids.join(",")})
-          order by c.display_order, c.name`;
-      categoriesResults = await pool.query(categoriesSql);
-    }
-  } catch (err) {
-    return Promise.reject(err.message);
-  }
-
-  stakeholderResult.rows.forEach((row) => {
-    stakeholders.push({
-      id: row.id,
-      name: row.name || "",
-      address1: row.address_1 || "",
-      address2: row.address_2 || "",
-      city: row.city || "",
-      state: row.state || "",
-      zip: row.zip || "",
-      phone: row.phone || "",
-      latitude: row.latitude ? Number(row.latitude) : null,
-      longitude: row.longitude ? Number(row.longitude) : null,
-      distance: row.distance ? Number(row.distance) : null,
-      website: row.website || "",
-      notes: row.notes || "",
-      createdDate: row.created_date,
-      createdLoginId: row.created_login_id,
-      modifiedDate: row.modified_date,
-      modifiedLoginId: row.modified_login_id,
-      submittedDate: row.submitted_date,
-      submittedLoginId: row.submitted_login_id,
-      assignedDate: row.assigned_date,
-      assignedLoginId: row.assigned_login_id,
-      approvedDate: row.approved_date,
-      reviewedLoginId: row.reviewed_login_id,
-      claimedDate: row.claimed_date,
-      claimedLoginId: row.claimed_login_id,
-      requirements: row.requirements || "",
-      adminNotes: row.admin_notes || "",
-      inactive: row.inactive,
-      createdUser: row.created_user || "",
-      modifiedUser: row.modified_user || "",
-      submittedUser: row.submitted_user || "",
-      reviewedUser: row.reviewed_user || "",
-      assignedUser: row.assigned_user || "",
-      claimedUser: row.claimed_user || "",
-      categories: categoriesResults.rows.filter(
-        (cats) => cats.stakeholder_id == row.id
-      ),
-      hours: row.hours || [],
-      parentOrganization: row.parent_organization || "",
-      physicalAccess: row.physical_access || "",
-      email: row.email || "",
-      items: row.items || "",
-      services: row.services || "",
-      facebook: row.facebook || "",
-      twitter: row.twitter || "",
-      pinterest: row.pinterest || "",
-      linkedin: row.linkedin || "",
-      description: row.description,
-      reviewNotes: row.review_notes,
-      instagram: row.instagram || "",
-      adminContactName: row.admin_contact_name || "",
-      adminContactPhone: row.admin_contact_phone || "",
-      adminContactEmail: row.admin_contact_email || "",
-      donationContactName: row.donation_contact_name || "",
-      donationContactPhone: row.donation_contact_phone || "",
-      donationContactEmail: row.donation_contact_email || "",
-      donationPickup: row.donation_pickup || false,
-      donationAcceptFrozen: row.donation_accept_frozen || false,
-      donationAcceptRefrigerated: row.donation_accept_refrigerated || false,
-      donationAcceptPerishable: row.donation_accept_perishable || false,
-      donationSchedule: row.donation_schedule || "",
-      donationDeliveryInstructions: row.donation_delivery_instructions || "",
-      donationNotes: row.donation_notes || "",
-      covidNotes: row.covid_notes || "",
-      categoryNotes: row.category_notes || "",
-      eligibilityNotes: row.eligibility_notes || "",
-      foodTypes: row.food_types || "",
-      languages: row.languages || "",
-      confirmedName: row.v_name,
-      confirmedCategories: row.v_categories,
-      confirmedAddress: row.v_address,
-      confirmedPhone: row.v_phone,
-      confirmedEmail: row.v_email,
-      confirmedHours: row.v_hours,
-      verificationStatusId: row.verification_status_id,
-      inactiveTemporary: row.inactive_temporary,
-      neighborhoodId: row.neighborhood_id,
-      is_verified: row.is_verified,
-    });
-  });
-
-  return stakeholders;
-};
-
-const searchDashboard = async ({
   tenantId,
   name,
   categoryIds,
@@ -408,9 +250,9 @@ const selectById = async (id) => {
       s.category_notes, s.eligibility_notes, s.food_types, s.languages,
       s.v_name, s.v_categories, s.v_address, s.v_phone, s.v_email,
       s.v_hours, s.verification_status_id, s.inactive_temporary,
-      s.neighborhood_id, s.is_verified,
+      s.neighborhood_id, 
       ${buildLoginSelectsClause()}
-    from stakeholder_best s
+    from stakeholder s
     ${buildLoginJoinsClause()}
     where s.id = ${id}`;
   const result = await pool.query(sql);
@@ -490,7 +332,6 @@ const selectById = async (id) => {
     verificationStatusId: row.verification_status_id,
     inactiveTemporary: row.inactive_temporary,
     neighborhoodId: row.neighborhood_id,
-    is_verified: row.is_verified,
   };
 
   // Don't have a distance, since we didn't specify origin
@@ -1134,7 +975,6 @@ const buildLoginSelectsClause = () => {
 
 module.exports = {
   search,
-  searchDashboard,
   selectById,
   selectCsv,
   insert,

--- a/client/src/components/Results/ResultsContainer.js
+++ b/client/src/components/Results/ResultsContainer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 
-import { useOrganizations } from "hooks/useOrganizations/useOrganizations";
+import { useOrganizationBests } from "hooks/useOrganizationBests";
 import useCategoryIds from "hooks/useCategoryIds";
 import { isMobile } from "helpers";
 
@@ -35,7 +35,7 @@ export default function ResultsContainer(props) {
   // Component state
   const storage = window.sessionStorage;
   const { userCoordinates, userSearch, setToast } = props;
-  const { data, search } = useOrganizations();
+  const { data, search } = useOrganizationBests();
   const [sortedData, setSortedData] = useState([]);
   const classes = useStyles();
 

--- a/client/src/components/Verification/VerificationAdmin.js
+++ b/client/src/components/Verification/VerificationAdmin.js
@@ -8,7 +8,7 @@ import { SearchButton } from "../Buttons";
 import { PrimaryButton } from "../../ui";
 import StakeholderGrid from "./VerificationAdminGrid";
 import { RotateLoader } from "react-spinners";
-import { useOrganizations } from "hooks/useOrganizations/useOrganizations";
+import { useOrganizations } from "hooks/useOrganizations";
 import { useCategories } from "hooks/useCategories/useCategories";
 import { useTenants } from "hooks/useTenants/useTenants";
 import { useNeighborhoods } from "hooks/useNeighborhoods/useNeighborhoods";
@@ -153,7 +153,7 @@ function VerificationAdmin(props) {
     data: stakeholders,
     loading: stakeholdersLoading,
     error: stakeholdersError,
-    searchDashboard: stakeholderSearch,
+    search: stakeholderSearch,
   } = useOrganizations();
 
   const searchCallback = useCallback(stakeholderSearch, []);

--- a/client/src/components/Verification/VerificationDashboard.js
+++ b/client/src/components/Verification/VerificationDashboard.js
@@ -5,7 +5,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { SearchButton, PlainButton } from "../Buttons";
 import StakeholderGrid from "./VerificationAdminGrid";
 import { RotateLoader } from "react-spinners";
-import { useOrganizations } from "hooks/useOrganizations/useOrganizations";
+import { useOrganizations } from "hooks/useOrganizations";
 import * as stakeholderService from "services/stakeholder-service";
 
 const useStyles = makeStyles((theme) => ({
@@ -80,7 +80,7 @@ function VerificationDashboard(props) {
     data: stakeholders,
     loading: stakeholdersLoading,
     error: stakeholdersError,
-    searchDashboard: stakeholderSearch,
+    search: stakeholderSearch,
   } = useOrganizations();
 
   const searchCallback = useCallback(stakeholderSearch, []);

--- a/client/src/hooks/useOrganizationBests.js
+++ b/client/src/hooks/useOrganizationBests.js
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import * as stakeholderService from "../services/stakeholder-best-service";
+
+export const useOrganizationBests = () => {
+  const [state, setState] = useState({
+    data: null,
+    loading: false,
+    error: false,
+  });
+
+  const search = async ({
+    name,
+    latitude,
+    longitude,
+    radius,
+    categoryIds,
+    isInactive,
+    verificationStatusId,
+  }) => {
+    if (!latitude || !longitude) {
+      setState({ data: null, loading: false, error: true });
+      const msg =
+        "Call to search function missing latitude and/or longitude parameters";
+      console.error(msg);
+      return Promise.reject(msg);
+    }
+    //if (!categoryIds || categoryIds.length === 0) return;
+    try {
+      setState({ data: null, loading: true, error: false });
+      const stakeholders = await stakeholderService.search({
+        name,
+        categoryIds,
+        latitude,
+        longitude,
+        distance: radius,
+        isInactive,
+        verificationStatusId,
+      });
+      setState({ data: stakeholders, loading: false, error: false });
+      return stakeholders;
+    } catch (err) {
+      setState({ data: null, loading: false, error: true });
+      console.error(err);
+      return Promise.reject(err);
+    }
+  };
+
+  return { ...state, search };
+};

--- a/client/src/hooks/useOrganizations.js
+++ b/client/src/hooks/useOrganizations.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import * as stakeholderService from "../../services/stakeholder-service";
+import * as stakeholderService from "../services/stakeholder-service";
 
 export const useOrganizations = () => {
   const [state, setState] = useState({
@@ -9,43 +9,6 @@ export const useOrganizations = () => {
   });
 
   const search = async ({
-    name,
-    latitude,
-    longitude,
-    radius,
-    categoryIds,
-    isInactive,
-    verificationStatusId,
-  }) => {
-    if (!latitude || !longitude) {
-      setState({ data: null, loading: false, error: true });
-      const msg =
-        "Call to search function missing latitude and/or longitude parameters";
-      console.error(msg);
-      return Promise.reject(msg);
-    }
-    //if (!categoryIds || categoryIds.length === 0) return;
-    try {
-      setState({ data: null, loading: true, error: false });
-      const stakeholders = await stakeholderService.search({
-        name,
-        categoryIds,
-        latitude,
-        longitude,
-        distance: radius,
-        isInactive,
-        verificationStatusId,
-      });
-      setState({ data: stakeholders, loading: false, error: false });
-      return stakeholders;
-    } catch (err) {
-      setState({ data: null, loading: false, error: true });
-      console.error(err);
-      return Promise.reject(err);
-    }
-  };
-
-  const searchDashboard = async ({
     tenantId,
     name,
     latitude,
@@ -68,7 +31,7 @@ export const useOrganizations = () => {
   }) => {
     try {
       setState({ data: null, loading: true, error: false });
-      const stakeholders = await stakeholderService.searchDashboard({
+      const stakeholders = await stakeholderService.search({
         tenantId,
         name,
         latitude,
@@ -98,5 +61,5 @@ export const useOrganizations = () => {
     }
   };
 
-  return { ...state, search, searchDashboard };
+  return { ...state, search };
 };

--- a/client/src/services/stakeholder-best-service.js
+++ b/client/src/services/stakeholder-best-service.js
@@ -1,0 +1,61 @@
+import axios from "axios";
+import moment from "moment";
+import { getTenantId } from "helpers/Configuration";
+
+const baseUrl = "/api/stakeholderbests";
+
+const toLocalMoment = (ts) => {
+  return !ts ? null : moment.utc(ts).local();
+};
+
+/* 
+    searchParams is an object with any/all of the following properties:
+        name - look for this string as substring of the stakeholder's name
+        categoryIds - array of integers corresponding to the desired categories
+        latitude
+        longitude
+        distance - radius around latitude and longitude
+        isAssigned - ("yes", "no", "either")
+        isSubmitted - ("yes", "no", "either")
+        isApproved - ("yes", "no", "either")
+        isClaimed - ("yes", "no", "either")
+        assignedLoginId
+        claimedLoginId
+*/
+export const search = async (searchParams) => {
+  searchParams = searchParams || {};
+  const response = await axios.get(baseUrl, {
+    params: {
+      ...searchParams,
+      tenantId: getTenantId(),
+    },
+  });
+  let stakeholders = response.data.map((s) => {
+    return {
+      ...s,
+      createdDate: toLocalMoment(s.createdDate),
+      modifiedDate: toLocalMoment(s.modifiedDate),
+      assignedDate: toLocalMoment(s.assignedDate),
+      submittedDate: toLocalMoment(s.submittedDate),
+      approvedDate: toLocalMoment(s.approvedDate),
+      claimedDate: toLocalMoment(s.claimedDate),
+    };
+  });
+
+  // console.log("stakeholders", stakeholders);
+  return stakeholders;
+};
+
+export const getById = async (id) => {
+  const response = await axios.get(`${baseUrl}/${id}`);
+  const s = response.data;
+  return {
+    ...s,
+    createdDate: toLocalMoment(s.createdDate),
+    modifiedDate: toLocalMoment(s.modifiedDate),
+    assignedDate: toLocalMoment(s.assignedDate),
+    submittedDate: toLocalMoment(s.submittedDate),
+    approvedDate: toLocalMoment(s.approvedDate),
+    claimedDate: toLocalMoment(s.claimedDate),
+  };
+};

--- a/client/src/services/stakeholder-service.js
+++ b/client/src/services/stakeholder-service.js
@@ -9,47 +9,9 @@ const toLocalMoment = (ts) => {
   return !ts ? null : moment.utc(ts).local();
 };
 
-/* 
-    searchParams is an object with any/all of the following properties:
-        name - look for this string as substring of the stakeholder's name
-        categoryIds - array of integers corresponding to the desired categories
-        latitude
-        longitude
-        distance - radius around latitude and longitude
-        isAssigned - ("yes", "no", "either")
-        isSubmitted - ("yes", "no", "either")
-        isApproved - ("yes", "no", "either")
-        isClaimed - ("yes", "no", "either")
-        assignedLoginId
-        claimedLoginId
-*/
 export const search = async (searchParams) => {
   searchParams = searchParams || {};
-  const response = await axios.get(baseUrl, {
-    params: {
-      ...searchParams,
-      tenantId: getTenantId(),
-    },
-  });
-  let stakeholders = response.data.map((s) => {
-    return {
-      ...s,
-      createdDate: toLocalMoment(s.createdDate),
-      modifiedDate: toLocalMoment(s.modifiedDate),
-      assignedDate: toLocalMoment(s.assignedDate),
-      submittedDate: toLocalMoment(s.submittedDate),
-      approvedDate: toLocalMoment(s.approvedDate),
-      claimedDate: toLocalMoment(s.claimedDate),
-    };
-  });
-
-  // console.log("stakeholders", stakeholders);
-  return stakeholders;
-};
-
-export const searchDashboard = async (searchParams) => {
-  searchParams = searchParams || {};
-  const response = await axios.get(`${baseUrl}/dashboard`, {
+  const response = await axios.get(`${baseUrl}`, {
     params: searchParams,
   });
   let stakeholders = response.data.map((s) => {


### PR DESCRIPTION
Fixes #690 

The GET /api/stakeholder/:id web api endpoint was returning the corresponding stakeholder_best record, which is ok for the food seeker UI, but incorrect for the admin UI, where we need to work with the latest draft of the stakeholder. I segregated the stakeholder (aka organization) queries from teh stakeholderBest (aka organizationBest) queries in the web api as well as the client-side services and hooks, to make a clear distinction between queries for the Food Seeker UI vs queries for the Admin UI.