### PR TITLE
Buttons and themes

### DIFF
--- a/client/src/components/Buttons.js
+++ b/client/src/components/Buttons.js
@@ -86,12 +86,7 @@ const DeleteButton = (props) => {
 
 const DeleteIconButton = (props) => {
   return (
-    <IconButton
-      variant="contained"
-      color="default"
-      aria-label="delete"
-      {...props}
-    >
+    <IconButton variant="contained" aria-label="delete" {...props}>
       <Delete />
     </IconButton>
   );

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -15,7 +15,7 @@ Header.propTypes = {
   setToast: PropTypes.func,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   headerHolder: {
     backgroundColor: (props) => props.headerColor,
     marginBottom: (props) => props.headerMargin,
@@ -24,6 +24,10 @@ const useStyles = makeStyles({
   header: {
     minHeight: "60px",
     padding: "0 1.5em 0 0",
+    [theme.breakpoints.down("xs")]: {
+      padding: "0 0.5em 0 0",
+      minHeight: "45px",
+    },
   },
   content: {
     display: "flex",
@@ -35,9 +39,11 @@ const useStyles = makeStyles({
     width: "90px",
     height: "60px",
     margin: "0 .5rem",
-
     "&:hover": {
       filter: "brightness(1.2)",
+    },
+    [theme.breakpoints.down("xs")]: {
+      height: "45px",
     },
   },
   tagline: {
@@ -47,7 +53,7 @@ const useStyles = makeStyles({
     lineHeight: "1.5",
     fontFamily: `"HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans- serif`,
   },
-});
+}));
 
 export default function Header(props) {
   const { user, setUser, setToast } = props;

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -26,23 +26,24 @@ Menu.propTypes = {
   setToast: PropTypes.func,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   list: {
     width: 250,
   },
   menuButton: {
     transform: "scale(1.6,1.5)",
-    backgroundColor: "#FFF",
-    padding: "0.5rem",
     minWidth: "0",
     "&:hover": {
       backgroundColor: "#FFF",
+    },
+    [theme.breakpoints.down("xs")]: {
+      transform: "scale(1.2, 1.2)",
     },
   },
   blueMenu: {
     fill: "#19334D",
   },
-});
+}));
 
 export default function Menu(props) {
   const isHomePage = useLocationHook();

--- a/client/src/components/Results/ResultsContainer.js
+++ b/client/src/components/Results/ResultsContainer.js
@@ -12,16 +12,6 @@ import List from "./ResultsList";
 import Map from "./ResultsMap";
 
 const useStyles = makeStyles((theme) => ({
-  filterButton: {
-    margin: "0 .25rem",
-    padding: "0 0.5rem",
-    fontSize: "12px",
-  },
-  div: {
-    textAlign: "center",
-    fontSize: "12px",
-    border: "1px solid blue",
-  },
   listMapContainer: {
     [theme.breakpoints.down("sm")]: {
       height: "100%",

--- a/client/src/components/Results/ResultsFilters.js
+++ b/client/src/components/Results/ResultsFilters.js
@@ -1,14 +1,7 @@
 import React, { useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
-import {
-  Grid,
-  Select,
-  MenuItem,
-  FormControl,
-  Button,
-  Box,
-} from "@material-ui/core";
+import { Grid, Select, MenuItem, Button, Box } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
 
 import {
@@ -18,75 +11,22 @@ import {
 } from "constants/stakeholder";
 import { isMobile } from "helpers";
 
+import theme from "theme/materialUI";
 import SwitchViewsButton from "components/SwitchViewsButton";
 import Search from "components/Search";
 
 const useStyles = makeStyles((theme) => ({
-  filterGroup: {
-    margin: 0,
-    padding: 0,
-  },
-  filterGroupButton: {
-    margin: 0,
-    padding: ".5rem",
-    fontSize: "max(.8vw,12px)",
-    whiteSpace: "nowrap",
-    backgroundColor: "#fff",
-    border: ".1em solid #000",
-    color: "#000",
-    [theme.breakpoints.down("xs")]: {
-      padding: ".1rem .1rem",
-      margin: "0",
-      fontSize: "max(.8vw,11px)",
-    },
-  },
-  filterButton: {
-    margin: 0,
-    padding: ".5rem",
-    fontSize: "max(.8vw,12px)",
-    whiteSpace: "nowrap",
-    backgroundColor: "#fff",
-    border: ".1em solid #000",
-    color: "#000",
-    [theme.breakpoints.down("xs")]: {
-      padding: ".6rem .6rem",
-      margin: ".3rem",
-      fontSize: "max(.8vw,12px)",
-      borderRadius: "5px !important",
-    },
-  },
-  distanceControl: {
-    margin: ".3rem",
-    backgroundColor: "#fff",
-    // padding: "auto 0 auto .7em",
-    padding: ".3rem",
-    border: ".1em solid #000",
-    outline: "none",
-    [theme.breakpoints.down("xs")]: {
-      padding: ".4rem",
-      margin: ".3rem",
-    },
+  select: {
+    color: "white",
   },
   menuItems: {
     fontSize: "max(.8vw,12px)",
     color: "#000",
   },
   controlPanel: {
-    backgroundColor: "#336699",
+    backgroundColor: theme.palette.primary.main,
     padding: "1rem 0",
     flex: "1 0 auto",
-  },
-  inputHolder: {
-    display: "flex",
-    justifyContent: "flex-start",
-    alignItems: "center",
-  },
-  input: {
-    fontSize: "12px",
-    width: "25em",
-    height: "2em",
-    outline: "none",
-    padding: ".25em",
   },
   inputContainer: {
     display: "flex",
@@ -120,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
   buttonHolder: {
     display: "flex",
     [theme.breakpoints.down("xs")]: {
-      marginTop: "1rem",
+      marginTop: "0.5rem",
     },
   },
 }));
@@ -146,7 +86,6 @@ const ResultsFilters = ({
   switchResultsView,
 }) => {
   const classes = useStyles();
-
   const isMealsSelected = categoryIds.indexOf(MEAL_PROGRAM_CATEGORY_ID) >= 0;
   const isPantrySelected = categoryIds.indexOf(FOOD_PANTRY_CATEGORY_ID) >= 0;
 
@@ -243,43 +182,42 @@ const ResultsFilters = ({
         className={classes.buttonHolder}
       >
         <Grid item>
-          <Button as={FormControl} className={classes.distanceControl}>
-            <Select
-              name="select-distance"
-              disableUnderline
-              value={radius}
-              onChange={(e) => handleDistanceChange(e.target.value)}
-              inputProps={{
-                name: "select-distance",
-                id: "select-distance",
-              }}
-              className={classes.menuItems}
-            >
-              <MenuItem key={0} value={0} className={classes.menuItems}>
-                DISTANCE
+          <Select
+            disableUnderline
+            value={radius}
+            onChange={(e) => handleDistanceChange(e.target.value)}
+            inputProps={{
+              classes: {
+                icon: classes.select,
+              },
+            }}
+            className={classes.select}
+          >
+            <MenuItem key={0} value={0} className={classes.menuItems}>
+              DISTANCE
+            </MenuItem>
+            {distanceInfo.map((distance) => (
+              <MenuItem
+                key={distance}
+                value={distance}
+                className={classes.menuItems}
+              >
+                {distance === 0
+                  ? "(Any)"
+                  : `${distance} MILE${distance > 1 ? "S" : ""}`}
               </MenuItem>
-              {distanceInfo.map((distance) => (
-                <MenuItem
-                  key={distance}
-                  value={distance}
-                  className={classes.menuItems}
-                >
-                  {distance === 0
-                    ? "(Any)"
-                    : `${distance} MILE${distance > 1 ? "S" : ""}`}
-                </MenuItem>
-              ))}
-            </Select>
-          </Button>
+            ))}
+          </Select>
         </Grid>
         <Grid item>
           <Button
-            className={classes.filterButton}
             style={{
-              backgroundColor: isPantrySelected ? "#0A3865" : "#fff",
+              backgroundColor: isPantrySelected
+                ? theme.palette.primary.dark
+                : "#fff",
               color: isPantrySelected ? "#fff" : "#000",
-              marginLeft: "0.25rem",
-              borderRadius: "5px 0 0 5px",
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
             }}
             onClick={togglePantry}
           >
@@ -304,12 +242,13 @@ const ResultsFilters = ({
         </Grid>
         <Grid item>
           <Button
-            className={classes.filterButton}
             style={{
-              backgroundColor: isMealsSelected ? "#0A3865" : "#fff",
+              backgroundColor: isMealsSelected
+                ? theme.palette.primary.dark
+                : "#fff",
               color: isMealsSelected ? "#fff" : "#000",
-              marginRight: "0.25rem",
-              borderRadius: "0 5px 5px 0",
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0,
             }}
             onClick={toggleMeal}
           >
@@ -337,18 +276,6 @@ const ResultsFilters = ({
               color="white"
             />
           )}
-          {/* <Button
-            className={classes.filterGroupButton}
-            style={{
-              backgroundColor: isVerifiedSelected ? "#0A3865" : "#fff",
-              color: isVerifiedSelected ? "#fff" : "#000",
-            }}
-            onClick={() => {
-              selectVerified(!isVerifiedSelected);
-            }}
-          >
-            Updated Data
-          </Button> */}
         </Grid>
       </Grid>
       <Box

--- a/client/src/components/Results/ResultsFilters.js
+++ b/client/src/components/Results/ResultsFilters.js
@@ -216,8 +216,6 @@ const ResultsFilters = ({
                 ? theme.palette.primary.dark
                 : "#fff",
               color: isPantrySelected ? "#fff" : "#000",
-              borderTopRightRadius: 0,
-              borderBottomRightRadius: 0,
             }}
             onClick={togglePantry}
           >
@@ -247,8 +245,7 @@ const ResultsFilters = ({
                 ? theme.palette.primary.dark
                 : "#fff",
               color: isMealsSelected ? "#fff" : "#000",
-              borderTopLeftRadius: 0,
-              borderBottomLeftRadius: 0,
+              marginLeft: "5px",
             }}
             onClick={toggleMeal}
           >

--- a/client/src/components/Results/ResultsMap.js
+++ b/client/src/components/Results/ResultsMap.js
@@ -13,12 +13,6 @@ import StakeholderDetails from "components/Stakeholder/StakeholderDetails";
 import Marker from "components/Marker";
 
 const styles = {
-  geolocate: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    margin: 10,
-  },
   navigationControl: {
     position: "absolute",
     top: 0,

--- a/client/src/components/Stakeholder/StakeholderDetails.js
+++ b/client/src/components/Stakeholder/StakeholderDetails.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
+import { Button } from "@material-ui/core";
 
 import mapMarker from "images/mapMarker";
 import fbIcon from "images/fbIcon.png";
@@ -14,7 +15,6 @@ import { extractNumbers, getGoogleMapsUrl } from "helpers";
 
 import Icon from "components/Icon";
 import SuggestionDialog from "components/SuggestionDialog";
-import { PlainButton } from "components/Buttons";
 
 const useStyles = makeStyles((theme, props) => ({
   stakeholder: {
@@ -87,6 +87,7 @@ const useStyles = makeStyles((theme, props) => ({
     left: "1em",
     alignSelf: "flex-start",
     margin: "1em 0 0 0",
+    cursor: "pointer",
   },
   label: {
     width: "100%",
@@ -105,6 +106,7 @@ const useStyles = makeStyles((theme, props) => ({
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
+    marginTop: "10px",
   },
   numbers: {
     display: "inline",
@@ -284,9 +286,8 @@ const StakeholderDetails = ({
         </p>
       ) : null}
       <div className={classes.buttons}>
-        <PlainButton
-          stakeholder={selectedStakeholder}
-          label="Directions"
+        <Button
+          variant="outlined"
           onClick={() =>
             window.open(
               getGoogleMapsUrl(
@@ -296,14 +297,12 @@ const StakeholderDetails = ({
               )
             )
           }
-        />
-        <PlainButton
-          className={classes.directions}
-          onClick={handleSuggestionDialogOpen}
-          label="Send a Correction"
         >
+          Directions
+        </Button>
+        <Button variant="outlined" onClick={handleSuggestionDialogOpen}>
           Send Correction
-        </PlainButton>
+        </Button>
       </div>
       {selectedStakeholder.hours ? (
         <>

--- a/client/src/components/Stakeholder/StakeholderDetails.js
+++ b/client/src/components/Stakeholder/StakeholderDetails.js
@@ -31,14 +31,6 @@ const useStyles = makeStyles((theme, props) => ({
     display: "inherit",
     justifyContent: "inherit",
   },
-  img: {
-    display: "inherit",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  typeLogo: {
-    width: "72px",
-  },
   info: {
     fontSize: "1.1em",
     textAlign: "left",

--- a/client/src/components/Stakeholder/StakeholderPreview.js
+++ b/client/src/components/Stakeholder/StakeholderPreview.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
 import { makeStyles } from "@material-ui/core/styles";
+import { Button } from "@material-ui/core";
 
 import {
   MEAL_PROGRAM_CATEGORY_ID,
@@ -11,7 +12,6 @@ import { ORGANIZATION_COLORS, CLOSED_COLOR } from "constants/map";
 import { getGoogleMapsUrl, extractNumbers } from "helpers";
 
 import Icon from "components/Icon";
-import { PlainButton } from "components/Buttons";
 
 const useStyles = makeStyles(() => ({
   stakeholder: {
@@ -208,8 +208,9 @@ const StakeholderPreview = ({ stakeholder, doSelectStakeholder }) => {
           ) : null}
         </div>
         <div className={classes.buttons}>
-          <PlainButton
-            label="Directions"
+          <Button
+            variant="outlined"
+            size="small"
             onClick={() =>
               window.open(
                 getGoogleMapsUrl(
@@ -219,16 +220,21 @@ const StakeholderPreview = ({ stakeholder, doSelectStakeholder }) => {
                 )
               )
             }
-            size="small"
-          />
+          >
+            Directions
+          </Button>
           {mainNumber && (
-            <PlainButton
-              label="Call"
+            <Button
+              variant="outlined"
               size="small"
               onClick={() => window.open(`tel:${mainNumber.value}`)}
-            />
+            >
+              Call
+            </Button>
           )}
-          <PlainButton label="Details" />
+          <Button variant="outlined" size="small">
+            Details
+          </Button>
         </div>
       </div>
     </div>

--- a/client/src/components/SwitchViewsButton.js
+++ b/client/src/components/SwitchViewsButton.js
@@ -9,21 +9,17 @@ export default function SwitchViewsButton({
   color = "primary",
 }) {
   return (
-    <Button
-      onClick={onClick}
-      title={`Go to ${isMapView ? "List" : "Map"}`}
-      style={{ color }}
-    >
+    <Button onClick={onClick} style={{ color }}>
       {isMapView && (
         <>
-          <span style={{ fontSize: "1rem", marginRight: ".5rem" }}>List</span>
           <FormatListBulletedIcon />
+          <span style={{ fontSize: "1rem", marginRight: ".5rem" }}>List</span>
         </>
       )}
       {!isMapView && (
         <>
+          <MapIcon />
           <span style={{ fontSize: "1rem", marginRight: ".5rem" }}>Map</span>
-          <MapIcon style={{ color: "#90C146" }} />
         </>
       )}
     </Button>

--- a/client/src/theme/materialUI.js
+++ b/client/src/theme/materialUI.js
@@ -3,18 +3,19 @@ import { createMuiTheme } from "@material-ui/core/styles";
 const theme = createMuiTheme({
   palette: {
     primary: {
-      // purple
-      // main: "#772f7a",
+      // blue
+      light: "#1976d2",
       main: "#336699",
       contrastText: "#ffffff",
     },
     secondary: {
       // orange
-      main: "rgb(249, 192, 88)",
+      main: "#f9c058",
       contrastText: "#000000",
     },
     error: {
-      main: "rgb(249, 64, 64)",
+      // red
+      main: "#f94040",
       contrastText: "#000000",
     },
     text: {
@@ -24,38 +25,40 @@ const theme = createMuiTheme({
   typography: {
     fontFamily: '"Helvetica Neue", Helvetica, sans-serif;',
   },
-  overrides: {
-    MuiButton: {
-      outlined: {
-        margin: "10px",
-        border: "2px solid #772f7a",
-        color: "#772f7a",
-        "&:hover": {
-          color: "hsl(298, 44%, 96%)",
-          backgroundColor: "#772f7a",
-        },
-      },
-    },
-    MuiLink: {
-      root: {
-        color: "#1976d2",
-        "&:visited": {
-          color: "#772f7a",
-        },
-      },
-      underlineHover: {
-        textDecoration: "none",
-        "&:hover": {
-          textDecoration: "underline",
-        },
-      },
-    },
-    MuiAppBar: {
-      root: {
-        backgroundColor: "rgb(241, 241, 241)",
+});
+
+const { primary } = theme.palette;
+
+theme.overrides = {
+  MuiButton: {
+    outlined: {
+      border: `2px solid ${primary.main}`,
+      color: primary.main,
+      "&:hover": {
+        color: primary.contrastText,
+        backgroundColor: primary.main,
       },
     },
   },
-});
+  MuiLink: {
+    root: {
+      color: primary.light,
+      "&:visited": {
+        color: primary.main,
+      },
+    },
+    underlineHover: {
+      textDecoration: "none",
+      "&:hover": {
+        textDecoration: "underline",
+      },
+    },
+  },
+  MuiAppBar: {
+    root: {
+      backgroundColor: "#f1f1f1",
+    },
+  },
+};
 
 export default theme;

--- a/client/src/theme/materialUI.js
+++ b/client/src/theme/materialUI.js
@@ -6,6 +6,7 @@ const theme = createMuiTheme({
       // blue
       light: "#1976d2",
       main: "#336699",
+      dark: "#0A3865",
       contrastText: "#ffffff",
     },
     secondary: {


### PR DESCRIPTION
Fixes #732 

- Changes stakeholder preview and detail views to have outlined buttons
- Make the map filter buttons more consistent with each other
- Clean up `materialUI` theme and remove unnecessary styles and props

<img width="421" alt="Screen Shot 2020-10-13 at 10 49 45 PM" src="https://user-images.githubusercontent.com/4600967/95942266-5d8b2900-0da8-11eb-9a81-7ff4e16d3037.png">
<img width="435" alt="Screen Shot 2020-10-13 at 10 49 39 PM" src="https://user-images.githubusercontent.com/4600967/95942271-5f54ec80-0da8-11eb-88d7-99335cc7c8bb.png">
