### PR TITLE
Bounds Search

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,7 +4,7 @@ import { makeStyles, ThemeProvider } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 import theme from "theme/materialUI";
 import { logout } from "services/account-service";
-import { tenantId, originCoordinates } from "helpers/Configuration";
+import { tenantId, defaultCoordinates } from "helpers/Configuration";
 
 // Components
 import { UserContext } from "components/user-context";
@@ -75,8 +75,8 @@ function App() {
   const [toast, setToast] = useState({ message: "" });
   const [bgImg, setBgImg] = useState("");
   const [origin, setOrigin] = useState({
-    latitude: originCoordinates.lat,
-    longitude: originCoordinates.lon,
+    latitude: defaultCoordinates.lat,
+    longitude: defaultCoordinates.lon,
   });
 
   useEffect(() => {
@@ -127,8 +127,8 @@ function App() {
         (error) => {
           console.log(`Getting browser location failed: ${error.message}`);
           const userCoordinates = {
-            latitude: originCoordinates.lat,
-            longitude: originCoordinates.lon,
+            latitude: defaultCoordinates.lat,
+            longitude: defaultCoordinates.lon,
           };
           setUserCoordinates(userCoordinates);
         }
@@ -176,7 +176,8 @@ function App() {
               <Route path="/organizations">
                 <Results
                   userCoordinates={userCoordinates}
-                  userSearch={origin}
+                  origin={origin}
+                  setOrigin={setOrigin}
                   setToast={setToast}
                 />
               </Route>

--- a/client/src/components/Results/ResultsFilters.js
+++ b/client/src/components/Results/ResultsFilters.js
@@ -72,7 +72,6 @@ const useStyles = makeStyles((theme) => ({
   },
   submit: {
     height: "40px",
-    // minWidth: "25px",
     backgroundColor: "#BCE76D",
     borderRadius: "0 6px 6px 0",
     boxShadow: "none",

--- a/client/src/components/Results/ResultsFilters.js
+++ b/client/src/components/Results/ResultsFilters.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
 import { Grid, Button, Box } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
+import LocationSearchingIcon from "@material-ui/icons/LocationSearching";
 
 import {
   MEAL_PROGRAM_CATEGORY_ID,
@@ -31,9 +32,35 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
   },
+  form: {
+    all: "inherit",
+    backgroundColor: "white",
+    borderRadius: "6px",
+  },
   searchIcon: {
     width: 32,
     height: 32,
+  },
+  nearbyIcon: {
+    maxWidth: "25px",
+    padding: 0,
+  },
+  nearbySearch: {
+    height: "40px",
+    minWidth: "25px",
+    borderRadius: 0,
+    backgroundColor: "white",
+    boxShadow: "none",
+    "& .MuiButton-startIcon": {
+      margin: 0,
+    },
+    "&.Mui-disabled": {
+      opacity: 0.8,
+      backgroundColor: "white",
+    },
+    "&:hover": {
+      boxShadow: "none",
+    },
   },
   submit: {
     height: "40px",
@@ -43,6 +70,7 @@ const useStyles = makeStyles((theme) => ({
     boxShadow: "none",
     "& .MuiButton-startIcon": {
       marginRight: 0,
+      marginLeft: "3px",
     },
     "&.Mui-disabled": {
       backgroundColor: "#BCE76D",
@@ -186,12 +214,19 @@ const ResultsFilters = ({
         <form
           noValidate
           onSubmit={(e) => handleSearch(e)}
-          style={{ all: "inherit" }}
+          className={classes.form}
         >
           <Search
             userCoordinates={userCoordinates}
             setOrigin={setOrigin}
             origin={origin}
+          />
+          <Button
+            onClick={() => setOrigin(userCoordinates)}
+            disabled={!userCoordinates.latitude || !userCoordinates.longitude}
+            variant="contained"
+            className={classes.nearbySearch}
+            startIcon={<LocationSearchingIcon className={classes.nearbyIcon} />}
           />
           <Button
             type="submit"

--- a/client/src/components/Results/ResultsFilters.js
+++ b/client/src/components/Results/ResultsFilters.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
-import { Grid, Select, MenuItem, Button, Box } from "@material-ui/core";
+import { Grid, Button, Box } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
 
 import {
@@ -64,22 +64,15 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const distanceInfo = [0, 1, 2, 3, 5, 10, 20, 50, 100, 500];
-
 const ResultsFilters = ({
   handleSearch,
   isWindowWide,
-  viewport,
-  setViewport,
   origin,
   setOrigin,
-  radius,
-  setRadius,
   isVerifiedSelected,
   userCoordinates,
   categoryIds,
   toggleCategory,
-  viewPortHash,
   isMapView,
   switchResultsView,
 }) => {
@@ -98,15 +91,7 @@ const ResultsFilters = ({
   useEffect(() => {
     handleSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [origin, radius, categoryIds, isVerifiedSelected, toggleCategory]);
-
-  const handleDistanceChange = (distance) => {
-    setRadius(distance);
-    setViewport({
-      ...viewport,
-      zoom: viewPortHash[distance],
-    });
-  };
+  }, [origin, categoryIds, isVerifiedSelected, toggleCategory]);
 
   return (
     <Grid
@@ -128,34 +113,6 @@ const ResultsFilters = ({
         alignItems="center"
         className={classes.buttonHolder}
       >
-        <Grid item>
-          <Select
-            disableUnderline
-            value={radius}
-            onChange={(e) => handleDistanceChange(e.target.value)}
-            inputProps={{
-              classes: {
-                icon: classes.select,
-              },
-            }}
-            className={classes.select}
-          >
-            <MenuItem key={0} value={0} className={classes.menuItems}>
-              DISTANCE
-            </MenuItem>
-            {distanceInfo.map((distance) => (
-              <MenuItem
-                key={distance}
-                value={distance}
-                className={classes.menuItems}
-              >
-                {distance === 0
-                  ? "(Any)"
-                  : `${distance} MILE${distance > 1 ? "S" : ""}`}
-              </MenuItem>
-            ))}
-          </Select>
-        </Grid>
         <Grid item>
           <Button
             style={{

--- a/client/src/components/Results/ResultsFilters.js
+++ b/client/src/components/Results/ResultsFilters.js
@@ -30,14 +30,13 @@ const useStyles = makeStyles((theme) => ({
     position: "sticky",
     top: "48px",
     zIndex: 1,
-    [theme.breakpoints.up("md")]: {
-      justifyContent: "center",
-    },
+    justifyContent: "center",
   },
   inputContainer: {
     display: "flex",
     alignItems: "center",
     width: "100%",
+    maxWidth: "30rem",
     margin: "0 0.5rem",
   },
   form: {
@@ -73,7 +72,7 @@ const useStyles = makeStyles((theme) => ({
   },
   submit: {
     height: "40px",
-    minWidth: "25px",
+    // minWidth: "25px",
     backgroundColor: "#BCE76D",
     borderRadius: "0 6px 6px 0",
     boxShadow: "none",

--- a/client/src/components/Results/ResultsMap.js
+++ b/client/src/components/Results/ResultsMap.js
@@ -81,8 +81,16 @@ function Map({
 
   const searchArea = () => {
     setShowSearchArea(false);
-    const center = mapRef.current.getMap().getCenter();
-    handleSearch(null, center);
+    const map = mapRef.current.getMap();
+    const center = map.getCenter();
+    const mapBounds = map.getBounds();
+    const bounds = {
+      maxLat: mapBounds._ne.lat,
+      minLat: mapBounds._sw.lat,
+      maxLng: mapBounds._ne.lng,
+      minLng: mapBounds._sw.lng,
+    };
+    handleSearch(null, center, bounds);
   };
 
   const unselectStakeholder = () => {
@@ -118,8 +126,6 @@ function Map({
       >
         <ReactMapGL
           {...viewport}
-          /* dragPan={isWindowWide && isMobile ? false : true} */
-          // touchAction="pan-y pinch-zoom"
           ref={mapRef}
           width="100%"
           height="100%"

--- a/client/src/components/Results/ResultsMap.js
+++ b/client/src/components/Results/ResultsMap.js
@@ -196,8 +196,6 @@ function Map({
 Map.propTypes = {
   stakeholders: PropTypes.array,
   categoryIds: PropTypes.arrayOf(PropTypes.number).isRequired,
-  selectedLatitude: PropTypes.number.isRequired,
-  selectedLongitude: PropTypes.number.isRequired,
 };
 
 export default Map;

--- a/client/src/components/Search.js
+++ b/client/src/components/Search.js
@@ -77,8 +77,6 @@ export default function Search({ userCoordinates, setOrigin, origin }) {
   });
 
   const handleInputChange = (event) => {
-    console.log(event);
-    // if (!event.target.value) return;
     setSelectedPlace(event.target.value);
     updateNewInputValue(event.target.value);
     fetchMapboxResults(event.target.value);

--- a/client/src/components/Verification/SearchCriteria.js
+++ b/client/src/components/Verification/SearchCriteria.js
@@ -20,7 +20,7 @@ import {
 import RadioTrueFalseEither from "../RadioTrueFalseEither";
 import LocationAutocomplete from "../LocationAutocomplete";
 import AccountAutocomplete from "../AccountAutocomplete";
-import { originCoordinates } from "../../helpers/Configuration";
+import { defaultCoordinates } from "../../helpers/Configuration";
 
 const useStyles = makeStyles((theme) => ({
   card: {
@@ -58,8 +58,10 @@ const SearchCriteria = ({
       : "custom"
   );
 
-  const [customLatitude, setCustomLatitude] = useState(originCoordinates.lat);
-  const [customLongitude, setCustomLongitude] = useState(originCoordinates.lon);
+  const [customLatitude, setCustomLatitude] = useState(defaultCoordinates.lat);
+  const [customLongitude, setCustomLongitude] = useState(
+    defaultCoordinates.lon
+  );
   const [customPlaceName, setCustomPlaceName] = useState("");
 
   useEffect(() => {

--- a/client/src/helpers/Configuration.js
+++ b/client/src/helpers/Configuration.js
@@ -9,7 +9,7 @@ export const tenantId = (() =>
     ? 2
     : 1)();
 
-export const originCoordinates = (() => {
+export const defaultCoordinates = (() => {
   switch (tenantId) {
     case 3:
       return { lat: 21.3101548, lon: -157.8428712, zoom: 12, radius: 5 };

--- a/client/src/helpers/Configuration.js
+++ b/client/src/helpers/Configuration.js
@@ -12,10 +12,10 @@ export const tenantId = (() =>
 export const originCoordinates = (() => {
   switch (tenantId) {
     case 3:
-      return { lat: 21.33629, lon: -157.89435 };
+      return { lat: 21.3101548, lon: -157.8428712, zoom: 12, radius: 5 };
     case 2:
-      return { lat: 38.576711, lon: -121.493671 };
+      return { lat: 38.3949164, lon: -122.7287326, zoom: 10, radius: 8 };
     default:
-      return { lat: 34.07872, lon: -118.243328 };
+      return { lat: 34.0354899, lon: -118.2439235, zoom: 12, radius: 5 };
   }
 })();

--- a/client/src/hooks/useOrganizationBests.js
+++ b/client/src/hooks/useOrganizationBests.js
@@ -13,6 +13,7 @@ export const useOrganizationBests = () => {
     latitude,
     longitude,
     radius,
+    bounds,
     categoryIds,
     isInactive,
     verificationStatusId,
@@ -27,7 +28,7 @@ export const useOrganizationBests = () => {
     //if (!categoryIds || categoryIds.length === 0) return;
     try {
       setState({ data: null, loading: true, error: false });
-      const stakeholders = await stakeholderService.search({
+      let params = {
         name,
         categoryIds,
         latitude,
@@ -35,7 +36,18 @@ export const useOrganizationBests = () => {
         distance: radius,
         isInactive,
         verificationStatusId,
-      });
+      };
+      if (bounds) {
+        const { maxLat, maxLng, minLat, minLng } = bounds;
+        params = {
+          ...params,
+          maxLng,
+          maxLat,
+          minLng,
+          minLat,
+        };
+      }
+      const stakeholders = await stakeholderService.search(params);
       setState({ data: stakeholders, loading: false, error: false });
       return stakeholders;
     } catch (err) {

--- a/client/src/services/stakeholder-best-service.js
+++ b/client/src/services/stakeholder-best-service.js
@@ -14,6 +14,10 @@ const toLocalMoment = (ts) => {
         categoryIds - array of integers corresponding to the desired categories
         latitude
         longitude
+        maxLat - optional
+        maxLng - optional
+        minLat - optional
+        minLng - optional
         distance - radius around latitude and longitude
         isAssigned - ("yes", "no", "either")
         isSubmitted - ("yes", "no", "either")


### PR DESCRIPTION
- Add optional max/min Lat and Lng bounds to organization search. If there are bounds we will search by that, otherwise we will fall back on a center lat, lng with a distance radius
- "Search this area" will search by bounds
- Change default centers, radius, and zoom for each org to make sure our default view is centered where we have data, at a useful zoom level, and a large enough radius to fill the whole map on desktop
- Refactor how the map center "origin" is calculated. (combine and remove redundant variables, rename some variables, remove unnecessary sessionStorage variables)
- Add a button to the search bar to search your current location (if we have it, otherwise its disabled)

<img width="513" alt="Screen Shot 2020-10-28 at 2 10 58 PM" src="https://user-images.githubusercontent.com/4600967/97491170-68f15f00-1927-11eb-8f1b-a535e399db22.png">
