### PR TITLE
Add bounding box for food types #786

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "food-oasis-client",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/src/components/Verification/OrganizationEdit.js
+++ b/client/src/components/Verification/OrganizationEdit.js
@@ -1111,7 +1111,18 @@ const OrganizationEdit = (props) => {
                   <Grid item xs={12}>
                     <Typography>Details for Food Seekers to See</Typography>
                   </Grid>
-                  <Grid item container justify="space-between" xs={12}>
+                  <Grid
+                    item
+                    container
+                    justify="space-between"
+                    xs={12}
+                    style={{
+                      border: "1px solid gray",
+                      borderRadius: "4px",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
                     <Grid item xs={6}>
                       <Typography>Food Types</Typography>
                     </Grid>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "foodoasis",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Closes #786

### Changes
- Add a border around food types to make it more clear that you need to confirm the selected food types
- version numbers

### Note
The version numbers inside the `package-lock.json`s were changed automatically 🤔 Let me know if I should put it back to version `1.0.31`