### PR TITLE
Group food types together

### DIFF
--- a/client/src/components/Verification/OrganizationEdit.js
+++ b/client/src/components/Verification/OrganizationEdit.js
@@ -202,6 +202,49 @@ const emptyOrganization = {
   foodMeat: false,
 };
 
+const FOOD_TYPES = [
+  {
+    name: "foodBakery",
+    label: "Baked Goods",
+  },
+  {
+    name: "foodDryGoods",
+    label: "Dry Goods",
+  },
+  {
+    name: "foodProduce",
+    label: "Produce",
+  },
+  {
+    name: "foodDairy",
+    label: "Dairy",
+  },
+  {
+    name: "foodPrepared",
+    label: "Prepared Food",
+  },
+  {
+    name: "foodMeat",
+    label: "Meat",
+  },
+];
+
+const CheckboxWithLabel = ({ name, label, checked, onChange, ...props }) => (
+  <Grid item xs={12} sm={4}>
+    <FormControlLabel
+      control={
+        <Checkbox
+          name={name}
+          checked={checked}
+          onChange={onChange}
+          {...props}
+        />
+      }
+      label={label}
+    />
+  </Grid>
+);
+
 const OrganizationEdit = (props) => {
   const { classes, setToast, match, user, history } = props;
   const editId = match.params.id;
@@ -1116,12 +1159,7 @@ const OrganizationEdit = (props) => {
                     container
                     justify="space-between"
                     xs={12}
-                    style={{
-                      border: "1px solid gray",
-                      borderRadius: "4px",
-                      display: "flex",
-                      alignItems: "center",
-                    }}
+                    alignItems="center"
                   >
                     <Grid item xs={6}>
                       <Typography>Food Types</Typography>
@@ -1148,114 +1186,24 @@ const OrganizationEdit = (props) => {
                       />
                     </Grid>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          margin="normal"
-                          name="foodBakery"
-                          label="Bakery"
-                          value={values.foodBakery}
-                          checked={values.foodBakery}
-                          onChange={() =>
-                            setFieldValue("foodBakery", !values.foodBakery)
-                          }
+                  <Grid
+                    container
+                    alignItems="center"
+                    style={{ maxWidth: "600px" }}
+                  >
+                    {FOOD_TYPES.map(({ name, label }) => {
+                      const checked = values[name];
+                      return (
+                        <CheckboxWithLabel
+                          key={name}
+                          name={name}
+                          label={label}
+                          checked={checked}
+                          onChange={() => setFieldValue(name, !checked)}
                           onBlur={handleBlur}
                         />
-                      }
-                      label="Baked Goods"
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          margin="normal"
-                          name="foodDryGoods"
-                          label="Dry Goods"
-                          value={values.foodDryGoods}
-                          checked={values.foodDryGoods}
-                          onChange={() =>
-                            setFieldValue("foodDryGoods", !values.foodDryGoods)
-                          }
-                          onBlur={handleBlur}
-                        />
-                      }
-                      label="Dry Goods"
-                    />
-                  </Grid>
-
-                  <Grid item xs={12} sm={4}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          margin="normal"
-                          name="foodProduce"
-                          label="Produce"
-                          value={values.foodProduce}
-                          checked={values.foodProduce}
-                          onChange={() =>
-                            setFieldValue("foodProduce", !values.foodProduce)
-                          }
-                          onBlur={handleBlur}
-                        />
-                      }
-                      label="Produce"
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          margin="normal"
-                          name="foodDairy"
-                          label="Dairy"
-                          value={values.foodDairy}
-                          checked={values.foodDairy}
-                          onChange={() =>
-                            setFieldValue("foodDairy", !values.foodDairy)
-                          }
-                          onBlur={handleBlur}
-                        />
-                      }
-                      label="Dairy"
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          margin="normal"
-                          name="foodPrepared"
-                          label="Prepared Food"
-                          value={values.foodPrepared}
-                          checked={values.foodPrepared}
-                          onChange={() =>
-                            setFieldValue("foodPrepared", !values.foodPrepared)
-                          }
-                          onBlur={handleBlur}
-                        />
-                      }
-                      label="Prepared Food"
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          margin="normal"
-                          name="foodMeat"
-                          label="Meat"
-                          value={values.foodMeat}
-                          checked={values.foodMeat}
-                          onChange={() =>
-                            setFieldValue("foodMeat", !values.foodMeat)
-                          }
-                          onBlur={handleBlur}
-                        />
-                      }
-                      label="Meat"
-                    />
+                      );
+                    })}
                   </Grid>
                 </Grid>
                 <Grid item xs={12}>


### PR DESCRIPTION
Closes #786

### Changes
- Refactor food types so it's easier to add more in the future
- Wrap the food types with a grid container and add a `maxWidth` so the food types are grouped together
![Screen Shot 2020-12-15 at 11 34 47 PM](https://user-images.githubusercontent.com/25972384/102447106-27566980-3fe4-11eb-95be-12a322996acd.png)

### Notes
- I removed the `margin` prop as I'm not sure if it's doing anything 😅  I checked the `<Checkbox />` API and it's not there > https://material-ui.com/api/checkbox/
 