### PR TITLE
Get Client Url from client request for registration, forgot password

### DIFF
--- a/app/controllers/account-controller.js
+++ b/app/controllers/account-controller.js
@@ -40,8 +40,10 @@ const register = async (req, res) => {
 
 const resendConfirmationEmail = async (req, res) => {
   try {
+    const { email, clientUrl } = req.body;
     const response = await accountService.resendConfirmationEmail(
-      req.body.email
+      email,
+      clientUrl
     );
     res.send(response);
   } catch (err) {

--- a/app/services/sendgrid-service.js
+++ b/app/services/sendgrid-service.js
@@ -1,6 +1,5 @@
 const sgMail = require("@sendgrid/mail");
 const applyEmailTemplate = require("./EmailTemplate");
-const clientUrl = process.env.CLIENT_URL;
 const emailUser = process.env.EMAIL_USER;
 const sendgridKey = process.env.SENDGRID_API_KEY;
 
@@ -27,6 +26,7 @@ const send = async (emailTo, emailFrom, subject, textBody, htmlBody) => {
 const sendRegistrationConfirmation = async (
   email,
   token,
+  clientUrl,
   emailTemplate = applyEmailTemplate
 ) => {
   const emailBody = `
@@ -68,6 +68,7 @@ const sendRegistrationConfirmation = async (
 const sendResetPasswordConfirmation = async (
   email,
   token,
+  clientUrl,
   emailTemplate = applyEmailTemplate
 ) => {
   const emailBody = `

--- a/client/src/services/account-service.js
+++ b/client/src/services/account-service.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 const baseUrl = "/api/accounts";
+const clientUrl = window.location.origin;
 
 export const getAll = async () => {
   const response = await axios.get(baseUrl);
@@ -8,19 +9,19 @@ export const getAll = async () => {
 };
 
 export const register = async (firstName, lastName, email, password) => {
-  const body = { firstName, lastName, email, password };
+  const body = { firstName, lastName, email, password, clientUrl };
   const response = await axios.post(baseUrl + "/register", body);
   return response.data;
 };
 
 export const resendConfirmationEmail = async (email) => {
-  const body = { email };
+  const body = { email, clientUrl };
   const response = await axios.post(baseUrl + "/resendConfirmationEmail", body);
   return response.data;
 };
 
 export const forgotPassword = async (email) => {
-  const body = { email };
+  const body = { email, clientUrl };
   const response = await axios.post(baseUrl + "/forgotPassword", body);
   return response.data;
 };


### PR DESCRIPTION
This allows the confirm email and reset password emails to use a link with the correct url based on the client's url, rather than from an environment variable. This allows linking the email to the appropriate subdomain for the tenant.