### PR TITLE
Add a menu item to the main menu that is only available to admin user…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "foodoasis-client",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/src/components/Layout/Menu.js
+++ b/client/src/components/Layout/Menu.js
@@ -137,6 +137,11 @@ export default function Menu(props) {
                     to="/verificationadmin"
                     text="Verification Admin"
                   />
+                  <MenuItemLink
+                    key="viewusersuggestion"
+                    to="/viewusersuggestion"
+                    text="View User Suggestion"
+                  />
                   <Divider />
                 </>
               ) : null}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "foodoasis-web-api",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
#679 I have added a menu item to the main menu that is only available to admin user. This ideally links to a working page called View User Suggestion. At the moment, it is only linked to an empty page. (Branch cn/issue679)


