### PR TITLE
776 - (bugfix) add tenant_id filter to removeAll postgres query

### DIFF
--- a/server/app/services/stakeholder-service.js
+++ b/server/app/services/stakeholder-service.js
@@ -616,7 +616,7 @@ const insertBulk = async (stakeholderArray, action, tenantId) => {
       }
     }
   } else if (action === "replace") {
-    await removeAll();
+    await removeAll(tenantId);
     for (let i = 0; i < stakeholderArray.length; i++) {
       const model = camelcaseKeys(stakeholderArray[i]);
       model.tenantId = tenantId;
@@ -824,13 +824,26 @@ const remove = async (idParm) => {
   });
 };
 
-const removeAll = async () => {
+const removeAll = async (tenantId) => {
   await db.tx(async (t) => {
-    await t.none("delete from stakeholder_schedule");
-    await t.none("delete from stakeholder_category");
-    const result = await t.result("delete from stakeholder");
-    await t.none("delete from stakeholder_log");
-    await t.none("delete from stakeholder_best");
+    await t.none(
+      "delete from stakeholder_schedule where stakeholder_id in (select stakeholder_id from stakeholder where tenant_id = $<tenantId>)",
+      { tenantId }
+    );
+    await t.none(
+      "delete from stakeholder_category where stakeholder_id in (select stakeholder_id from stakeholder where tenant_id = $<tenantId>)",
+      { tenantId }
+    );
+    const result = await t.result(
+      "delete from stakeholder where tenant_id = $<tenantId>",
+      { tenantId }
+    );
+    await t.none("delete from stakeholder_log where tenant_id = $<tenantId>", {
+      tenantId,
+    });
+    await t.none("delete from stakeholder_best where tenant_id = $<tenantId>", {
+      tenantId,
+    });
     return result.rowCount;
   });
 };


### PR DESCRIPTION
I'll submit PRs from this repo from now on, we may remove the CodeForHawaii standalone repo. 

This should enforce the tenant ID when removeAll is called. I'm not an sql expert, so if there's a better way, feel free to refactor.