### PR TITLE
Map page performance

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16998,8 +16998,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-map-gl": {
       "version": "5.3.10",
@@ -17228,6 +17227,19 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
+      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "reactcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.2",
     "react-spinners": "^0.10.4",
+    "react-virtualized": "^9.22.3",
     "yup": "^0.32.8"
   },
   "browserslist": {

--- a/client/src/components/FoodSeeker/Marker.js
+++ b/client/src/components/FoodSeeker/Marker.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
 import { makeStyles } from "@material-ui/core/styles";
 
-import mapMarker from "images/mapMarker";
+import MapMarkerIcon from "images/mapMarker";
 import {
   MEAL_PROGRAM_CATEGORY_ID,
   FOOD_PANTRY_CATEGORY_ID,
@@ -32,17 +32,19 @@ const MapMarker = ({ onClick, stakeholder, selectedStakeholder }) => {
       latitude={latitude}
       className={selected ? classes.active : ""}
     >
-      {mapMarker(
-        categories[0]?.id === FOOD_PANTRY_CATEGORY_ID &&
+      <MapMarkerIcon
+        category={
+          categories[0]?.id === FOOD_PANTRY_CATEGORY_ID &&
           categories[1]?.id === MEAL_PROGRAM_CATEGORY_ID
-          ? -1
-          : categories[0]?.id === FOOD_PANTRY_CATEGORY_ID
-          ? 0
-          : 1,
-        inactiveTemporary || inactive,
-        onClick,
-        selected
-      )}
+            ? -1
+            : categories[0]?.id === FOOD_PANTRY_CATEGORY_ID
+            ? 0
+            : 1
+        }
+        inactive={inactiveTemporary || inactive}
+        onClick={onClick}
+        selected={selected}
+      />
     </Marker>
   );
 };

--- a/client/src/components/FoodSeeker/MarkerHelpers.js
+++ b/client/src/components/FoodSeeker/MarkerHelpers.js
@@ -1,0 +1,117 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import MapMarker from "images/mapMarker";
+import {
+  MEAL_PROGRAM_CATEGORY_ID,
+  FOOD_PANTRY_CATEGORY_ID,
+} from "constants/stakeholder";
+
+///////////////////// CONSTANTS ///////////////////
+
+// note that we have 3 marker categories, and 2 selected states, for a
+// total of 6 possible marker variants.
+// the marker categories come from src/images/mapMarker.js
+const MARKER_CATEGORIES = [-1, 0, 1];
+const SELECTED_VALUES = [false, true];
+
+// using the pixel ratio to scale the marker helps prevent
+// blurry edges when the marker is converted to an image
+const MARKER_SCALE = window.devicePixelRatio;
+
+////////////////////// FUNCTIONS //////////////////
+
+// each marker variant has a unique id based on its category and
+// whether it is selected
+function getIconId(markerCategory, isSelected) {
+  return `fola-marker::${markerCategory}::${isSelected}`
+}
+
+// selects the right marker category based on the stakeholder categories array.
+// category ids are from src/images/mapMarker.js
+function getMarkerCategory(stakeholder) {
+  if (
+    stakeholder.categories[0]?.id === FOOD_PANTRY_CATEGORY_ID &&
+    stakeholder.categories[1]?.id === MEAL_PROGRAM_CATEGORY_ID
+  )
+    return -1;
+
+  if (stakeholder.categories[0]?.id === FOOD_PANTRY_CATEGORY_ID) return 0;
+
+  return 1;
+}
+
+// This converts the given marker to an icon, and then loads that icon into the
+// map. Once loaded, the icon can be used in a symbol layer.
+// see https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#symbol
+function loadMarkerIcon({ map, marker, iconId }) {
+  return new Promise((resolve, reject) => {
+    const icon = new Image();
+    const svgString = renderToString(marker);
+    const svg = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(svg);
+    icon.src = url;
+    icon.onload = () => {
+      map.addImage(iconId, icon);
+      URL.revokeObjectURL(url);
+      resolve();
+    };
+  });
+}
+
+// load an icon for each possible combination of marker category and
+// selected value.
+export function loadMarkerIcons(map) {
+  const iconLoaders = []
+
+  MARKER_CATEGORIES.forEach((category) => {
+    SELECTED_VALUES.forEach((selected) => {
+      iconLoaders.push(
+        loadMarkerIcon({
+          map,
+          marker: (
+            <MapMarker
+              category={category}
+              selected={selected}
+              scale={MARKER_SCALE}
+            />
+          ),
+          iconId: getIconId(category, selected),
+        })
+      )
+    })
+  })
+
+  return Promise.all(iconLoaders)
+}
+
+export const markersLayerStyles = {
+  type: "symbol",
+  layout: {
+    "icon-image": ["get", "iconId"],
+    "icon-allow-overlap": true,
+    "icon-size": 1 / MARKER_SCALE,
+  },
+}
+
+// This generates the geojson needed to show the stakeholders in a symbol layer.
+// Note that the iconId is added as a property.
+export function getMarkersGeojson(stakeholders, selectedStakeholder) {
+  return {
+    type: "FeatureCollection",
+    features: (stakeholders || []).map((sh) => {
+      const category = getMarkerCategory(sh)
+      const selected = sh.id === selectedStakeholder?.id
+      return {
+        type: "Feature",
+        id: sh.id,
+        geometry: {
+          type: "Point",
+          coordinates: [sh.longitude, sh.latitude],
+        },
+        properties: {
+          iconId: getIconId(category, selected),
+        },
+      }
+    }),
+  }
+}

--- a/client/src/components/FoodSeeker/ResultsContainer.js
+++ b/client/src/components/FoodSeeker/ResultsContainer.js
@@ -10,7 +10,7 @@ import { defaultCoordinates } from "helpers/Configuration";
 import { DEFAULT_CATEGORIES } from "constants/stakeholder";
 
 import Filters from "./ResultsFilters";
-import List from "./ResultsList";
+import List from "./ResultsListOptimized";
 import Map from "./ResultsMap";
 import * as analytics from "../../services/analytics";
 

--- a/client/src/components/FoodSeeker/ResultsContainer.js
+++ b/client/src/components/FoodSeeker/ResultsContainer.js
@@ -11,7 +11,7 @@ import { DEFAULT_CATEGORIES } from "constants/stakeholder";
 
 import Filters from "./ResultsFilters";
 import List from "./ResultsListOptimized";
-import Map from "./ResultsMap";
+import Map from "./ResultsMapOptimized";
 import * as analytics from "../../services/analytics";
 
 const useStyles = makeStyles((theme) => ({

--- a/client/src/components/FoodSeeker/ResultsListOptimized.js
+++ b/client/src/components/FoodSeeker/ResultsListOptimized.js
@@ -1,0 +1,162 @@
+import React, { useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import { Button, CircularProgress, Grid } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import List from "react-virtualized/dist/es/List";
+import AutoSizer from "react-virtualized/dist/es/AutoSizer";
+import CellMeasurer from "react-virtualized/dist/es/CellMeasurer";
+import CellMeasurerCache from "react-virtualized/dist/es/CellMeasurer/CellMeasurerCache";
+import StakeholderPreview from "components/FoodSeeker/StakeholderPreview";
+import StakeholderDetails from "components/FoodSeeker/StakeholderDetails";
+import * as analytics from "services/analytics";
+
+const useStyles = makeStyles((theme) => ({
+  listContainer: {
+    textAlign: "center",
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    [theme.breakpoints.up("md")]: {
+      height: "100%",
+    },
+    [theme.breakpoints.only("sm")]: {
+      order: 1,
+      height: "30em",
+    },
+    [theme.breakpoints.down("xs")]: {
+      height: "100%",
+      fontSize: "12px",
+    },
+  },
+  list: {
+    width: "100%",
+    flex: 1,
+  },
+  preview: {
+    width: "100%",
+    borderBottom: " .2em solid #f1f1f1",
+    padding: "0 1em",
+  },
+  emptyResult: {
+    padding: "1em 0",
+    display: "flex",
+    flexDirection: "column",
+    alignContent: "center",
+  },
+}));
+
+const cache = new CellMeasurerCache({
+  defaultHeight: 140,
+  fixedWidth: true,
+});
+
+const clearCache = () => cache.clearAll();
+
+const ResultsList = ({
+  doSelectStakeholder,
+  selectedStakeholder,
+  stakeholders,
+  setToast,
+  status,
+  handleReset,
+}) => {
+  const classes = useStyles();
+
+  useEffect(() => {
+    analytics.postEvent("showList");
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("resize", clearCache);
+    return () => window.removeEventListener("resize", clearCache);
+  }, []);
+
+  useEffect(() => {
+    clearCache();
+  }, [stakeholders]);
+
+  const scrollToIndex = selectedStakeholder
+    ? stakeholders.findIndex((s) => s.id === selectedStakeholder.id)
+    : 0;
+
+  const rowRenderer = useCallback(
+    ({ index, style, key, parent }) => (
+      <CellMeasurer
+        key={key}
+        cache={cache}
+        parent={parent}
+        columnIndex={0}
+        rowIndex={index}
+      >
+        {({ registerChild }) => (
+          <div ref={registerChild} style={style} className={classes.preview}>
+            <StakeholderPreview
+              stakeholder={stakeholders[index]}
+              doSelectStakeholder={doSelectStakeholder}
+            />
+          </div>
+        )}
+      </CellMeasurer>
+    ),
+    [stakeholders, doSelectStakeholder, classes.preview]
+  );
+
+  return (
+    <Grid item xs={12} md={4} className={classes.listContainer}>
+      {status === "loading" && (
+        <div className={classes.emptyResult}>
+          <CircularProgress />
+        </div>
+      )}
+      {status === "loaded" && stakeholders.length === 0 && (
+        <div className={classes.emptyResult}>
+          <p>Sorry, we don&apos;t have any results for this area.</p>
+          <Button
+            onClick={handleReset}
+            variant="contained"
+            color="primary"
+            disableElevation
+          >
+            Click here to reset the search
+          </Button>
+        </div>
+      )}
+      {stakeholders && selectedStakeholder && !selectedStakeholder.inactive ? (
+        <StakeholderDetails
+          doSelectStakeholder={doSelectStakeholder}
+          selectedStakeholder={selectedStakeholder}
+          setToast={setToast}
+        />
+      ) : (
+        <div className={classes.list}>
+          <AutoSizer>
+            {({ height, width }) => (
+              <List
+                width={width}
+                height={height}
+                rowCount={stakeholders.length}
+                rowRenderer={rowRenderer}
+                deferredMeasurementCache={cache}
+                rowHeight={cache.rowHeight}
+                scrollToIndex={scrollToIndex}
+              />
+            )}
+          </AutoSizer>
+        </div>
+      )}
+    </Grid>
+  );
+};
+
+ResultsList.propTypes = {
+  selectedStakeholder: PropTypes.object,
+  stakeholders: PropTypes.arrayOf(PropTypes.object),
+  doSelectStakeholder: PropTypes.func,
+  setToast: PropTypes.func,
+  status: PropTypes.string,
+  handleReset: PropTypes.func,
+};
+
+export default ResultsList;

--- a/client/src/components/FoodSeeker/ResultsMapOptimized.js
+++ b/client/src/components/FoodSeeker/ResultsMapOptimized.js
@@ -1,0 +1,289 @@
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+} from "react";
+import PropTypes from "prop-types";
+import ReactMapGL, {
+  NavigationControl,
+  ScaleControl,
+  AttributionControl,
+  Source,
+  Layer,
+} from "react-map-gl";
+import { Grid, Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { MAPBOX_STYLE } from "constants/map";
+import { DEFAULT_CATEGORIES } from "constants/stakeholder";
+import { isMobile } from "helpers";
+import StakeholderPreview from "components/FoodSeeker/StakeholderPreview";
+import StakeholderDetails from "components/FoodSeeker/StakeholderDetails";
+import * as analytics from "services/analytics";
+import {
+  loadMarkerIcons,
+  markersLayerStyles,
+  getMarkersGeojson,
+} from "./MarkerHelpers";
+
+const styles = {
+  navigationControl: {
+    position: "absolute",
+    top: 0,
+    right: 30,
+    margin: "8px",
+    marginRight: "40px",
+    zIndex: 5,
+  },
+  scaleControl: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    margin: "8px",
+
+    zIndex: 5,
+  },
+  attributionStyle: {
+    right: 10,
+    bottom: 0,
+  },
+};
+
+const useStyles = makeStyles((theme) => ({
+  map: {
+    textAlign: "center",
+    fontSize: "12px",
+    [theme.breakpoints.up("md")]: {
+      height: "100%",
+    },
+    [theme.breakpoints.down("xs")]: {
+      height: (props) =>
+        props.selectedStakeholder ? "calc(100% - 120px)" : "100%",
+    },
+    [theme.breakpoints.only("sm")]: {
+      order: 0,
+      height: "50%",
+    },
+    position: "relative",
+  },
+  preview: {
+    margin: "0 1em",
+  },
+  details: {
+    textAlign: "center",
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    padding: "0 1em",
+  },
+  searchButton: {
+    position: "absolute",
+    top: "5px",
+    left: "50%",
+    transform: "translate(-50%)",
+    backgroundColor: "white",
+    zIndex: 1000,
+  },
+}));
+
+const MARKERS_LAYER_ID = "markers";
+
+const getCursor = ({ isHovering, isDragging }) => {
+  return isDragging ? "grabbing" : isHovering ? "pointer" : "grab";
+};
+
+function Map({
+  handleSearch,
+  stakeholders,
+  categoryIds,
+  doSelectStakeholder,
+  selectedStakeholder,
+  viewport,
+  setViewport,
+  setToast,
+}) {
+  const [showDetails, setShowDetails] = useState(false);
+  const [showSearchArea, setShowSearchArea] = useState(false);
+  const [mapReady, setMapReady] = useState(false);
+  const classes = useStyles();
+  const mapRef = useRef();
+  const categoryIdsOrDefault = categoryIds.length
+    ? categoryIds
+    : DEFAULT_CATEGORIES;
+
+  useEffect(() => {
+    analytics.postEvent("showMap");
+
+    const map = mapRef.current.getMap();
+    map.on("load", async () => {
+      await loadMarkerIcons(map);
+      setMapReady(true);
+    });
+  }, []);
+
+  // modify the stakeholders array by:
+  // 1. filtering out the inactive orgs
+  // 2. limiting the categories for each org to the ones currently selecte4d
+  const modifiedStakeholders = useMemo(() => {
+    if (!stakeholders) return null;
+
+    return stakeholders
+      .filter(
+        (sh) =>
+          sh.latitude && sh.longitude && !(sh.inactive || sh.inactiveTemporary)
+      )
+      .map((stakeholder) => ({
+        ...stakeholder,
+        categories: stakeholder.categories.filter(({ id }) =>
+          categoryIdsOrDefault.includes(id)
+        ),
+      }));
+  }, [stakeholders, categoryIdsOrDefault]);
+
+  const markersGeojson = useMemo(() => {
+    return getMarkersGeojson(modifiedStakeholders, selectedStakeholder);
+  }, [modifiedStakeholders, selectedStakeholder]);
+
+  const onInteractionStateChange = (s) => {
+    // don't do anything if the mapview is moving
+    if (
+      s.isDragging ||
+      s.inTransition ||
+      s.isRotating ||
+      s.isZooming ||
+      s.isHovering ||
+      s.isPanning
+    )
+      return;
+    // make sure map has already loaded
+    if (mapRef && mapRef.current && mapRef.current) {
+      setShowSearchArea(true);
+    }
+  };
+
+  const searchArea = (e) => {
+    setShowSearchArea(false);
+    const map = mapRef.current.getMap();
+    const center = map.getCenter();
+    const mapBounds = map.getBounds();
+    const bounds = {
+      maxLat: mapBounds._ne.lat,
+      minLat: mapBounds._sw.lat,
+      maxLng: mapBounds._ne.lng,
+      minLng: mapBounds._sw.lng,
+    };
+    analytics.postEvent("searchArea", {});
+    handleSearch(center, bounds);
+  };
+
+  const unselectStakeholder = useCallback(() => {
+    setShowDetails(false);
+    doSelectStakeholder(null);
+  }, [doSelectStakeholder]);
+
+  const handleClick = useCallback(
+    (e) => {
+      if (!e.features || !e.features.length) {
+        unselectStakeholder();
+      } else if (stakeholders) {
+        const { id } = e.features[0];
+        const selectedStakeholder = stakeholders.find((sh) => sh.id === id);
+        doSelectStakeholder(selectedStakeholder);
+      }
+    },
+    [stakeholders, unselectStakeholder, doSelectStakeholder]
+  );
+
+  const mobileView = isMobile();
+
+  if (showDetails && mobileView && selectedStakeholder) {
+    return (
+      <Grid item xs={12} md={4} className={classes.details}>
+        <StakeholderDetails
+          doSelectStakeholder={unselectStakeholder}
+          selectedStakeholder={selectedStakeholder}
+          setToast={setToast}
+        />
+      </Grid>
+    );
+  }
+
+  return (
+    <>
+      <Grid item xs={12} md={8} className={classes.map}>
+        <ReactMapGL
+          {...viewport}
+          ref={mapRef}
+          width="100%"
+          height="100%"
+          onViewportChange={(newViewport) => {
+            setViewport(newViewport);
+            // // Pass zooom level up to parent control, this allows us
+            // // to maintain zoom when search is re-executed, etc.
+            // setZoom(newViewport.zoom);
+          }}
+          mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
+          mapStyle={MAPBOX_STYLE}
+          onClick={handleClick}
+          onInteractionStateChange={onInteractionStateChange}
+          interactiveLayerIds={mapReady ? [MARKERS_LAYER_ID] : undefined}
+          getCursor={getCursor}
+        >
+          <AttributionControl
+            compact={mobileView}
+            style={styles.attributionStyle}
+          />
+          <div style={styles.navigationControl}>
+            <NavigationControl showCompass={false} />
+          </div>
+          <div style={styles.scaleControl}>
+            <ScaleControl
+              maxWidth={100}
+              unit="imperial"
+              className={classes.scaleControl}
+            />
+          </div>
+          {mapReady && (
+            <Source type="geojson" data={markersGeojson}>
+              <Layer id={MARKERS_LAYER_ID} {...markersLayerStyles} />
+            </Source>
+          )}
+        </ReactMapGL>
+        {showSearchArea && (
+          <Button
+            onClick={searchArea}
+            variant="outlined"
+            size="small"
+            className={classes.searchButton}
+          >
+            Search this area
+          </Button>
+        )}
+      </Grid>
+      {!!selectedStakeholder && mobileView && (
+        <Grid
+          item
+          xs={12}
+          md={8}
+          className={classes.preview}
+          onClick={() => setShowDetails(true)}
+        >
+          <StakeholderPreview
+            doSelectStakeholder={doSelectStakeholder}
+            stakeholder={selectedStakeholder}
+          />
+        </Grid>
+      )}
+    </>
+  );
+}
+
+Map.propTypes = {
+  stakeholders: PropTypes.array,
+  categoryIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  setZoom: PropTypes.func,
+};
+
+export default Map;

--- a/client/src/components/FoodSeeker/StakeholderDetails.js
+++ b/client/src/components/FoodSeeker/StakeholderDetails.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Button } from "@material-ui/core";
 
-import mapMarker from "images/mapMarker";
+import MapMarker from "images/mapMarker";
 import fbIcon from "images/fbIcon.png";
 import instaIcon from "images/instaIcon.png";
 import {
@@ -266,19 +266,25 @@ const StakeholderDetails = ({
                 .padEnd(4, "0")
             : selectedStakeholder.distance.toString().substring(0, 3)}{" "}
           mi
-          {mapMarker(
-            selectedStakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID &&
+          <MapMarker
+            category={
+              selectedStakeholder.categories[0].id ===
+                FOOD_PANTRY_CATEGORY_ID &&
               selectedStakeholder.categories[1] &&
               selectedStakeholder.categories[1].id === MEAL_PROGRAM_CATEGORY_ID
-              ? -1
-              : selectedStakeholder.categories[0].id === FOOD_PANTRY_CATEGORY_ID
-              ? 0
-              : 1,
-            selectedStakeholder.inactiveTemporary ||
+                ? -1
+                : selectedStakeholder.categories[0].id ===
+                  FOOD_PANTRY_CATEGORY_ID
+                ? 0
+                : 1
+            }
+            inactive={
+              selectedStakeholder.inactiveTemporary ||
               selectedStakeholder.inactive
-              ? true
-              : false
-          )}
+                ? true
+                : false
+            }
+          />
         </div>
       </div>
       {selectedStakeholder.verificationStatusId ===

--- a/client/src/images/mapMarker.js
+++ b/client/src/images/mapMarker.js
@@ -1,9 +1,15 @@
 import React from "react";
 import { foodPantry, mealProgram, closed } from "theme/colors";
 
-const MapMarker = (category, inactive, onClick, selected = false) => {
-  const width = selected ? "38px" : "30px";
-  const height = selected ? "50px" : "40px";
+const MapMarker = ({
+  category,
+  inactive,
+  onClick,
+  selected = false,
+  scale = 1.0,
+}) => {
+  const width = (selected ? 38 : 30) * scale;
+  const height = (selected ? 50 : 40) * scale;
   const filter = selected ? "url(#f1)" : "";
   let content;
 


### PR DESCRIPTION
This PR includes two optimized components for the map page --  ResultsMapOptimized and ResultsListOptimized. Together these components help keep the map page smooth and responsive even if there are a lot of pins being rendered (see #954). Here's how they work --

### ResultsMapOptimized 

The existing code uses the Marker component from `react-map-gl` to render the map markers. The problem there is that each Marker is rendered as an individual DOM element, which makes the DOM very heavy when there are lots of pins on the map, and results in poor performance when panning and zooming. 

To get around that, the optimized component renders the markers on a mapbox [symbol layer](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#symbol), which means that they are rendered on the map's canvas instead of as individual DOM elements. This method requires a bit more code, since you need to convert the markers to images, and load them into the map's style, before you can use them on the map. But the performance benefits are significant -- the map can handle hundreds of markers (probably thousands) without any noticeable lag in the panning and zooming. 

### ResultsListOptimized 

I noticed that there was a delay or a second or two in rendering the sidebar list when there were lots of items in the list.
The optimized component uses a virtualized list from [react-virtualized](https://www.npmjs.com/package/react-virtualized), a library designed for efficient rendering of large lists. The library's trick (under the hood) is to render only the visible items in the list instead of rendering all of them. 



