### PR TITLE
#939 background image not centered

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -76,10 +76,12 @@ const useStyles = makeStyles({
   },
   homeWrapper: {
     backgroundSize: "cover",
+    backgroundPosition:"center",
     minHeight: "max(100.7vh,20em)",
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
+    alignItems:"center",
   },
   verificationAdminWrapper: {
     flexBasis: "100%",


### PR DESCRIPTION
fixed #939 css bug where the map was not showing in the center of the screen

