### PR TITLE
Fix docker node upgrade breakage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:alpine as clientBuilder
 
 ENV NODE_ENV "development"
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
The Docker Hub node:alpine image was upgraded to node 17, causing the build to break, as described here: https://github.com/webpack/webpack/issues/14532

Added a node env variable to the Dockerfile to make the node 17 version work.  Should probably change the images we use to use LTS versions, though its not clear this would help in this case when v17 becomes LTS.