### PR TITLE
shorten tall toolbar

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/Filters/index.js
+++ b/client/src/components/FoodSeeker/SearchResults/Filters/index.js
@@ -26,7 +26,6 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.primary.white,
     color: theme.palette.primary.main,
     padding: "0.5rem 0",
-    flex: "1 0 auto",
     margin: 0,
     zIndex: 1,
     justifyContent: "center",


### PR DESCRIPTION
## Fixes #1102 

The toolbar was only tall on the largest screen size, medium and mobile screen did not have this bug.
