### PR TITLE
fix pre-filled send corrections form

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/SuggestionDialog.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/SuggestionDialog.js
@@ -30,6 +30,7 @@ function SuggestionDialog(props) {
   const [stakeholder, setStakeholder] = useState({
     ...DEFAULT_STAKEHOLDER,
     ...sh,
+    notes: "",
   });
 
   const handleCancel = () => {


### PR DESCRIPTION
fixes #1199 

This form inserts a new record into the "suggestion" table in the database and has not impact on the stakeholder table. The notes field has been cleared.