### PR TITLE
Update the url for 'Attend a training session' hyperlink

### DIFF
--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -182,7 +182,7 @@ const About = () => {
             <dt>How can I sign up to volunteer?</dt>
             <dd>
               <a
-                href="//laworks.com/opportunity/a0C3l00000iCS6GEAW"
+                href="//volunteer.laworks.com/opportunity/a0C3l00000r3wLvEAI/%E2%9A%99-help-the-hungry-with-phone-calls-and-research"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/components/StaticPagesCA/Faq.js
+++ b/client/src/components/StaticPagesCA/Faq.js
@@ -175,7 +175,7 @@ const About = () => {
             <dt>How can I sign up to volunteer?</dt>
             <dd>
               <a
-                href="//laworks.com/opportunity/a0C3l00000iCS6GEAW"
+                href="//volunteer.laworks.com/opportunity/a0C3l00000r3wLvEAI/%E2%9A%99-help-the-hungry-with-phone-calls-and-research"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/components/StaticPagesMCK/Faq.js
+++ b/client/src/components/StaticPagesMCK/Faq.js
@@ -175,7 +175,7 @@ const About = () => {
             <dt>How can I sign up to volunteer?</dt>
             <dd>
               <a
-                href="//laworks.com/opportunity/a0C3l00000iCS6GEAW"
+                href="//volunteer.laworks.com/opportunity/a0C3l00000r3wLvEAI/%E2%9A%99-help-the-hungry-with-phone-calls-and-research"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/components/StaticPagesPDX/Faq.js
+++ b/client/src/components/StaticPagesPDX/Faq.js
@@ -176,7 +176,7 @@ const About = () => {
             <dt>How can I sign up to volunteer?</dt>
             <dd>
               <a
-                href="//laworks.com/opportunity/a0C3l00000iCS6GEAW"
+                href="//volunteer.laworks.com/opportunity/a0C3l00000r3wLvEAI/%E2%9A%99-help-the-hungry-with-phone-calls-and-research"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/components/StaticPagesSB/Faq.js
+++ b/client/src/components/StaticPagesSB/Faq.js
@@ -175,7 +175,7 @@ const About = () => {
             <dt>How can I sign up to volunteer?</dt>
             <dd>
               <a
-                href="//laworks.com/opportunity/a0C3l00000iCS6GEAW"
+                href="//volunteer.laworks.com/opportunity/a0C3l00000r3wLvEAI/%E2%9A%99-help-the-hungry-with-phone-calls-and-research"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
### Overview

Updated the url in the FAQ page for '**Attend a training session**' hyperlink in the following file:

- [x] StaticPages
- [x] StaticPagesCA
- [x] StaticPagesMCK
- [x] StaticPagesPDX
- [x] StaticPagesSB
 
**Addresses:** [Link to "Attend a Training Session" in the For Volunteers section of website leads to an Error 404](https://github.com/hackforla/food-oasis/issues/1297)
