### PR TITLE
Add margin above the header for Auth screens

### DIFF
--- a/client/src/components/Layout/Footer.js
+++ b/client/src/components/Layout/Footer.js
@@ -61,7 +61,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 const Footer = () => {
-  const isHomePage = useLocationHook();
+  const {isHomePage} = useLocationHook();
   const classes = useStyles();
 
   const initialFooterSwitch = window.innerWidth >= 1000 ? true : false;

--- a/client/src/components/Layout/Header.js
+++ b/client/src/components/Layout/Header.js
@@ -5,6 +5,7 @@ import { AppBar, Toolbar, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { useUserContext } from "../../contexts/userContext";
 import { useSiteContext } from "../../contexts/siteContext";
+import useLocationHook from "hooks/useLocationHook";
 
 Header.propTypes = {
   tenantId: PropTypes.number,
@@ -35,6 +36,9 @@ const useStyles = makeStyles((theme) => ({
       padding: "0 0.5em 0 0",
       minHeight: "45px",
     },
+  },
+  spacedHeader: {
+    marginTop: theme.spacing(4),
   },
   logo: {
     maxWidth: "175px",
@@ -68,6 +72,7 @@ const useStyles = makeStyles((theme) => ({
 export default function Header() {
   const { tenantId } = useSiteContext();
   const classes = useStyles();
+  const { isAuthPage } = useLocationHook();
   const imageType = logoPaths
     ? logoPaths[tenantId].default.split(".").pop()
     : "unknown";
@@ -75,7 +80,12 @@ export default function Header() {
 
   return (
     <>
-      <AppBar position="sticky" className={classes.headerHolder}>
+      <AppBar
+        position="sticky"
+        className={`${classes.headerHolder} ${
+          isAuthPage && classes.spacedHeader
+        } `}
+      >
         <Toolbar className={classes.header}>
           <div>
             <a href="/">

--- a/client/src/components/Layout/Menu.js
+++ b/client/src/components/Layout/Menu.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function Menu() {
-  const isHomePage = useLocationHook();
+  const {isHomePage} = useLocationHook();
   const homePageStyles = {
     buttonColor: "#F1F1F1",
   };

--- a/client/src/hooks/useLocationHook.js
+++ b/client/src/hooks/useLocationHook.js
@@ -1,13 +1,28 @@
 import { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { matchPath, useLocation } from "react-router-dom";
 
 export default function useLocationHook() {
   const [isHomePage, setIsHomePage] = useState(false);
+  const [isAuthPage, setIsAuthPage] = useState(false);
   const location = useLocation();
+  const AUTHROUTES = [
+    "/login",
+    "/login/:email",
+    "/register",
+    "/forgotpassword",
+    "/forgotpassword/:email",
+  ];
+
+  const match = matchPath(location.pathname, {
+    path: AUTHROUTES,
+    exact: true,
+    strict: false,
+  });
 
   useEffect(() => {
     setIsHomePage(location.pathname === "/");
+    setIsAuthPage(match && match.isExact ? true : false);
   }, [location]);
 
-  return isHomePage;
+  return { isHomePage, isAuthPage };
 }


### PR DESCRIPTION
### **Overview**
Added margin above the header for the following Pages:

- [x]  Login
- [x]  Registration
- [x]  Forgot Password

**Addresses**: [Add margin above header for Login, Registration, Forgot Password Screens #1303](https://github.com/hackforla/food-oasis/issues/1303)