### PR TITLE
Fix bug where map was missing after PR#1353

### DIFF
--- a/client/src/theme/clientTheme.js
+++ b/client/src/theme/clientTheme.js
@@ -54,11 +54,6 @@ const theme = createTheme({
       },
     },
   },
-  breakpoints: {
-    values: {
-      sm: 630,
-    },
-  },
 });
 
 const { primary } = theme.palette;


### PR DESCRIPTION
Fixes #1390 
Problem is that if you want to customize the device width breakpoints in a Material-UI theme, you need to set the breakpoints for each width (xs, sm, md, lg, xl). For now, I am just reverting the the standard Material-UI breakpoints.

See https://mui.com/material-ui/customization/breakpoints/#default-breakpoints  for the directions.