### PR TITLE
Add Food Oasis partners link to their logo

### DIFF
--- a/client/src/components/StaticPages/About.js
+++ b/client/src/components/StaticPages/About.js
@@ -294,26 +294,34 @@ const About = () => {
             height='40'
           /> */}
           <Typography variant="h2">Our Partners</Typography>
-          <img
-            alt="Food Cycle LA"
-            src={foodCycle}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Food Forward"
-            src={foodForward}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Farm People"
-            src={farmPeople}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Food Bank"
-            src={foodBank}
-            className={classes.partnersLogo}
-          />
+          <a href="https://www.foodcyclela.org/" target={"_blank"}>
+            <img
+              alt="Food Cycle LA"
+              src={foodCycle}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://foodforward.org/" target={"_blank"}>
+            <img
+              alt="Food Forward"
+              src={foodForward}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://www.farm2people.org/" target={"_blank"}>
+            <img
+              alt="Farm People"
+              src={farmPeople}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://www.lafoodbank.org/" target={"_blank"}>
+            <img
+              alt="Food Bank"
+              src={foodBank}
+              className={classes.partnersLogo}
+            />
+          </a>
         </section>
       </div>
     </div>

--- a/client/src/components/StaticPagesMCK/About.js
+++ b/client/src/components/StaticPagesMCK/About.js
@@ -266,26 +266,34 @@ const About = () => {
         </section>
         <section className={classes.partners}>
           <h2>Our Partners</h2>
-          <img
-            alt="Food Cycle LA"
-            src={foodCycle}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Food Forward"
-            src={foodForward}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Farm People"
-            src={farmPeople}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Food Bank"
-            src={foodBank}
-            className={classes.partnersLogo}
-          />
+          <a href="https://www.foodcyclela.org/" target={"_blank"}>
+            <img
+              alt="Food Cycle LA"
+              src={foodCycle}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://foodforward.org/" target={"_blank"}>
+            <img
+              alt="Food Forward"
+              src={foodForward}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://www.farm2people.org/" target={"_blank"}>
+            <img
+              alt="Farm People"
+              src={farmPeople}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://www.lafoodbank.org/" target={"_blank"}>
+            <img
+              alt="Food Bank"
+              src={foodBank}
+              className={classes.partnersLogo}
+            />
+          </a>
         </section>
       </div>
     </div>

--- a/client/src/components/StaticPagesSB/About.js
+++ b/client/src/components/StaticPagesSB/About.js
@@ -203,26 +203,34 @@ const About = () => {
             height='40'
           /> */}
           <h2>Our Partners</h2>
-          <img
-            alt="Food Cycle LA"
-            src={foodCycle}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Food Forward"
-            src={foodForward}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Farm People"
-            src={farmPeople}
-            className={classes.partnersLogo}
-          />
-          <img
-            alt="Food Bank"
-            src={foodBank}
-            className={classes.partnersLogo}
-          />
+          <a href="https://www.foodcyclela.org/" target={"_blank"}>
+            <img
+              alt="Food Cycle LA"
+              src={foodCycle}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://foodforward.org/" target={"_blank"}>
+            <img
+              alt="Food Forward"
+              src={foodForward}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://www.farm2people.org/" target={"_blank"}>
+            <img
+              alt="Farm People"
+              src={farmPeople}
+              className={classes.partnersLogo}
+            />
+          </a>
+          <a href="https://www.lafoodbank.org/" target={"_blank"}>
+            <img
+              alt="Food Bank"
+              src={foodBank}
+              className={classes.partnersLogo}
+            />
+          </a>
         </section>
       </div>
     </div>


### PR DESCRIPTION
### **Overview**
Modified the logos to be links to the partner web sites in a new tab.

**Partner Sites:**

1. https://www.farm2people.org/
2. https://foodforward.org/
3. https://www.foodcyclela.org/
4. https://www.lafoodbank.org/

resolves #1428