### PR TITLE
1416 - Do not show 'Open Now' or 'Closing Soon' flags for organizations that do not accept walk-ins.

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
@@ -268,23 +268,22 @@ const StakeholderPreview = ({ stakeholder }) => {
             </em>
           ) : null}
 
-          {isOpenFlag &&
-          !(stakeholder.inactiveTemporary || stakeholder.inactive) ? (
-            <em className={classes.openLabel}>OPEN NOW</em>
-          ) : null}
-
-          {isAlmostClosedFlag &&
-          !(stakeholder.inactiveTemporary || stakeholder.inactive) &&
-          isAlmostClosedFlag ? (
-            <em className={classes.closingSoonLabel}>
-              {`Closing in ${minutesToClosing} minutes`}
-            </em>
-          ) : null}
-
           {showAllowWalkinsFlag &&
-          !(stakeholder.inactiveTemporary || stakeholder.inactive) ? (
-            <em className={classes.allowWalkinsLabel}>Walk-Ins Allowed</em>
-          ) : null}
+            !(stakeholder.inactiveTemporary || stakeholder.inactive) && (
+              <>
+                {isOpenFlag &&
+                  <em className={classes.openLabel}>OPEN NOW</em>
+                }
+                {isAlmostClosedFlag && 
+                  <em className={classes.closingSoonLabel}>
+                    {`Closing in ${minutesToClosing} minutes`}
+                  </em>
+                }
+                <em className={classes.allowWalkinsLabel}>Walk-Ins Allowed</em>
+              </>
+            )
+          }
+          
         </div>
         <div className={classes.buttons}>
           <Button


### PR DESCRIPTION
Addresses #1416 

Fix - in StakeholderPreview.js - Refactored conditional statements for OPEN NOW, Closing in X minutes, and Walk-ins Allowed to all be dependent on if showAllowWalkinsFlag is true.