### PR TITLE
Bugfix for #1538: Verification Admin search returns no results

### DIFF
--- a/server/app/services/aws-service.ts
+++ b/server/app/services/aws-service.ts
@@ -23,6 +23,9 @@ const autocomplete = async (address: string) => {
         "Language": "en"
     };
     const data = await location.searchPlaceIndexForText(params).promise().then(results => results)
+    data.Results.forEach((result) => {
+        result.Place.Geometry.Point?.push(result.Place.Geometry.Point.shift())
+    })
     return data
 }
 
@@ -36,7 +39,7 @@ const getCoords = async (address: string) => {
         "Language": "en"
     };
     const data = await location.searchPlaceIndexForText(params).promise().then(results => results)
-    console.log(data)
+    data.Results[0].Place.Geometry.Point?.push(data.Results[0].Place.Geometry.Point.shift())
     return data
 }
 


### PR DESCRIPTION
Addresses #1538 

AWS returns coordinates in longitude/latitude order instead of the usual latitude/longitude order, the way FOLA expects. This means our search function was trying to fetch results from out database for very far-off set of coordinates.
Added a method to swap the lat/long for the results objects AWS sends us, before our backend API sends the data to the front-end.