### PR TITLE
Hotfix: Geocoding Results

### DIFF
--- a/client/src/components/Admin/LocationAutocomplete.js
+++ b/client/src/components/Admin/LocationAutocomplete.js
@@ -18,9 +18,10 @@ const LocationAutocomplete = (props) => {
       // this request starts executing after the
       // setTimeout delay, this request is stale
       // and we don't want to run it.
+      const tenantId = process.env.REACT_APP_TENANT_ID;
       if (s.length > 8 && s === latestSearchString) {
-        const result = await awsService.autoComplete(s);
-        setGeocodeResults(result.Results);
+        const result = await awsService.autoComplete(s, tenantId);
+        setGeocodeResults(result);
       }
     }, 500);
   };
@@ -65,7 +66,7 @@ const LocationAutocomplete = (props) => {
                 {/* <Typography>{`${result.attributes.Addr_type}`}</Typography> */}
               </Grid>
             </div>
-          )
+          );
         })
       ) : (
         <div>No Results</div>

--- a/client/src/services/aws-service.js
+++ b/client/src/services/aws-service.js
@@ -1,9 +1,9 @@
 import axios from "axios";
 const baseUrl = "/api/aws";
 
-export const autoComplete = async (address) => {
+export const autoComplete = async (address, tenantId) => {
   const response = await axios.get(baseUrl + "/autocomplete", {
-    params: { address },
+    params: { address, tenantId },
   });
   return response.data;
 };
@@ -13,4 +13,4 @@ export const getCoords = async (address) => {
     params: { address },
   });
   return response.data;
-}
+};

--- a/server/app/controllers/aws-controller.ts
+++ b/server/app/controllers/aws-controller.ts
@@ -1,16 +1,16 @@
 import awsService from "../services/aws-service"
 import { RequestHandler } from "express";
-import { SearchPlaceIndexForTextResponse } from "aws-sdk/clients/location";
+import { SearchPlaceIndexForTextResponse, SearchForTextResult } from "aws-sdk/clients/location";
 
 const autocomplete: RequestHandler<
     never,
-    SearchPlaceIndexForTextResponse,
+    SearchForTextResult[],
     { params: string | Record<string, never> },
     never
 > = async (req, res) => {
     try {
-        const { address } = req.query;
-        const response = await awsService.autocomplete(address);
+        const { address, tenantId } = req.query;
+        const response = await awsService.autocomplete(address, tenantId);
         res.send(response);
     } catch (err) {
         console.error(err);

--- a/server/app/services/aws-service.ts
+++ b/server/app/services/aws-service.ts
@@ -14,7 +14,7 @@ const generateLocation = async () => {
     return location
 }
 
-const autocomplete = async (address: string) => {
+const autocomplete = async (address: string, tenantId: number) => {
     if (!process.env.PLACE_INDEX_NAME) return;
     const location = await generateLocation()
     const params: AWS.Location.SearchPlaceIndexForTextRequest = {
@@ -26,12 +26,14 @@ const autocomplete = async (address: string) => {
     };
     if (!location) return;
     const data = await location.searchPlaceIndexForText(params).promise().then(results => results)
-    data.Results.forEach((result) => {
-        const point: number | undefined = data.Results[0].Place.Geometry.Point?.shift()
+    const tenantRegions : { [key: number]: string } = {1: "California", 3: "Hawaii", 5: "Texas", 6: "California"};
+    const filtered = data.Results.filter((result) => result.Place.Region === tenantRegions[tenantId])
+    filtered.forEach((result) => {
+        const point: number | undefined = result.Place.Geometry.Point?.shift()
         if (!point) return;
         result.Place.Geometry.Point?.push(point)
     })
-    return data
+    return filtered
 }
 
 const getCoords = async (address: string) => {

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2193,16 +2193,21 @@
     "colId": "935a6129-c2af-4b69-85d3-9fb48a5243c4",
     "containerId": "ae763c3f-34d6-40dd-9749-50a88bd18b89",
     "name": "AWS Geocode Autocomplete",
-    "url": "http://localhost:5001/api/aws/autocomplete?address=1345 Turnbull Canyon Road",
+    "url": "http://localhost:5001/api/aws/autocomplete?address=Los Angeles&tenantId=1",
     "method": "GET",
     "sortNum": 600000,
     "created": "2023-01-09T21:59:20.949Z",
-    "modified": "2023-01-13T22:25:04.595Z",
+    "modified": "2023-04-06T01:54:05.429Z",
     "headers": [],
     "params": [
       {
         "name": "address",
-        "value": "1345 Turnbull Canyon Road",
+        "value": "Los Angeles",
+        "isPath": false
+      },
+      {
+        "name": "tenantId",
+        "value": "1",
         "isPath": false
       }
     ],
@@ -2226,16 +2231,16 @@
     "colId": "935a6129-c2af-4b69-85d3-9fb48a5243c4",
     "containerId": "ae763c3f-34d6-40dd-9749-50a88bd18b89",
     "name": "AWS Geocode Get Coordinates",
-    "url": "http://localhost:5001/api/aws/getCoords?address=1345 Turnbull Canyon Road",
+    "url": "http://localhost:5001/api/aws/getCoords?address=San Pedro",
     "method": "GET",
     "sortNum": 610000,
     "created": "2023-01-13T19:43:32.383Z",
-    "modified": "2023-01-13T22:25:25.080Z",
+    "modified": "2023-04-05T04:45:21.425Z",
     "headers": [],
     "params": [
       {
         "name": "address",
-        "value": "1345 Turnbull Canyon Road",
+        "value": "San Pedro",
         "isPath": false
       }
     ],


### PR DESCRIPTION
Fixed error where geocoder autocomplete was outputting results without point values.

Added filter to autocomplete that filters out results that are outside of tenant region.
To do this, frontend now passes tenant ID as a parameter to geocoder autocomplete.

Added tenant ID to autocomplete thunderclient test.