### PR TITLE
1490 Fix issue with disabled button tooltips

### DIFF
--- a/client/src/theme/overrides/Button.js
+++ b/client/src/theme/overrides/Button.js
@@ -5,14 +5,16 @@ export default function Button(theme) {
         disableRipple: true,
         disableTouchRipple: true,
       },
-      styleOverrides: {
-        root: {
-          "&:disabled": {
-            cursor: "not-allowed",
-            pointerEvents: "auto",
-          },
-        },
-      },
+      // I've commented out the style override for disabled buttons to address issue #1490, where the tooltips weren't working properly on disabled CTA buttons, also the same issue is on the main page. This change fixes the problem, but if any side effect occurs, we can always revert the change.
+
+      // styleOverrides: {
+      //   root: {
+      //     "&:disabled": {
+      //      cursor: "not-allowed",
+      //       pointerEvents: "auto",
+      //     },
+      //   },
+      // },
     },
     MuiButton: {
       defaultProps: {


### PR DESCRIPTION
### Overview
To resolve the issue, the code responsible for the `style override on disabled buttons` was commented out, which enables tooltips to work properly on these buttons.

Fixes #1490 