### PR TITLE
Changed the text color in Map View and List View Buttons

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
@@ -19,13 +19,13 @@ export default function SwitchViewsButton({ isListView, onClick, style }) {
       {!isListView && (
         <>
           <FormatListBulletedIcon />
-          <Typography variant="button">List</Typography>
+          <Typography variant="button" color="inherit">List</Typography>
         </>
       )}
       {isListView && (
         <>
           <MapIcon />
-          <Typography variant="button">Map</Typography>
+          <Typography variant="button" color="inherit">Map</Typography>
         </>
       )}
     </SwitchButton>


### PR DESCRIPTION
Fixes #1674 
* Changed the text color in the **Map View** and **List View** buttons when not hovered. 
* I changed it from black to white to improve accessibility by providing a higher contrast color scheme for button labels
* I did it by using the color="inherit" prop in the Typography elements
* The text and icons still turning black when hovering

Here are the screenshots of the buttons including their hovering states after the changes I introduced.
<img width="342" alt="map" src="https://github.com/hackforla/food-oasis/assets/98275292/74367c6b-eb41-4c2d-b8e4-000c7195fce5">
<img width="342" alt="map on hover" src="https://github.com/hackforla/food-oasis/assets/98275292/289386cf-5c9a-4e27-9b7d-8c1128cec3f9">
<img width="343" alt="list" src="https://github.com/hackforla/food-oasis/assets/98275292/244d1e03-cdb8-458a-be3a-0dc3146f8963">
<img width="351" alt="list on hover" src="https://github.com/hackforla/food-oasis/assets/98275292/14cb4f32-45f7-4f68-a029-61cbf3994f0f">

