### PR TITLE
Removed secondary style variant from Links

### DIFF
--- a/client/src/components/StaticPages/About.js
+++ b/client/src/components/StaticPages/About.js
@@ -197,7 +197,6 @@ const About = () => {
                 href="https://hackforla.org/"
                 target={"_blank"}
                 rel="noopener noreferrer"
-                variant="secondary"
               >
                 Hack for LA
               </Link>
@@ -219,7 +218,7 @@ const About = () => {
           <Typography variant="h2">Questions</Typography>
           <Typography variant="body1">
             For more information, please visit our{" "}
-            <Link to={"/faqs"} variant="secondary" component={RouterLink}>
+            <Link to={"/faqs"} component={RouterLink}>
               FAQ page
             </Link>
             .
@@ -246,7 +245,6 @@ const About = () => {
               Please contact our Support Team
               <br />
               <Link
-                variant="secondary"
                 href="mailto:foodoasisinfo@hackforla.org"
               >
                 foodoasisinfo@hackforla.org

--- a/client/src/theme/overrides/Link.js
+++ b/client/src/theme/overrides/Link.js
@@ -11,14 +11,6 @@ export default function Link(theme) {
     MuiLink: {
       variants: [
         {
-          props: { variant: "secondary" },
-          style: {
-            textDecoration: "none",
-            color: "#4D4D4D",
-            borderBottom: "1px solid #4D4D4D",
-          },
-        },
-        {
           props: { variant: "icon" },
           style: {
             textDecoration: "none",


### PR DESCRIPTION
Fixes #1682 
Removed Secondary style variant from Links
* Removed secondary variant from 3 Links in the About Page to revert them to their Primary Style as all the rest of the Links
* Removed the Secondary theme in `theme/overrides/Links.js`
* This is what they look like after removing their secondary style:
<img width="1492" alt="primary links" src="https://github.com/hackforla/food-oasis/assets/98275292/5ad5862c-036a-4980-8038-8910c7d7d494">
