### PR TITLE
Update Styling System to Use xs Prop in Material-UI Components (FAQ)

### DIFF
--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -1,144 +1,162 @@
 import React, { useEffect } from "react";
 import faqbg from "./assets/faq-bg.webp";
 import iconSpacerGray from "./assets/icon-spacer-gray.svg";
-import { Link, Typography, Container, Box } from "@mui/material";
+import IconSpacerSVG from "./assets/IconSpacerSVG";
+import { Link, Typography, Container, Box, CardMedia, SvgIcon } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import * as analytics from "../../services/analytics";
 import { Link as RouterLink } from "react-router-dom";
 import Footer from "../Layout/Footer";
+import { height } from "@mui/system";
 
-const useStyles = makeStyles(() => ({
-  // outer: {
-  //   background: "#fff",
-  // },
-  // main: {
-  //   padding: "1.5rem 0",
-  //   maxWidth: "1200px",
-  //   margin: "0 auto",
-  //   "& $ul": {
-  //     paddingLeft: "26px",
-  //     margin: "5px",
-  //     fontSize: "16px",
-  //     lineHeight: "26.55px",
-  //   },
-  //   "@media only screen and (min-width: 75em)": {
-  //     padding: "1.5rem 2rem",
-  //   },
-  // },
-  // title: {
-  //   textTransform: "uppercase",
-  //   fontWeight: 500,
-  //   textAlign: "center",
-  //   background: "#FFF",
-  //   margin: 0,
-  //   padding: "32px 0",
-  //   "& $span": {
-  //     "& $span": {
-  //       textTransform: "none",
-  //     },
-  //   },
-  // },
-  figure: {
-    margin: 0,
-    padding: 0,
-  },
-  icon: {
-    margin: "auto",
-    marginBottom: "20px",
-  },
-  // glossary: {
-  //   padding: "50px 32px 50px",
-  //   margin: "32px 0",
-  //   borderRadius: "24px",
-  //   background: "#f0f0f0",
-  //   display: "flex",
-  //   flexWrap: "wrap",
-  //   "& $h2": {
-  //     flexBasis: "100%",
-  //     textAlign: "center",
-  //     fontWeight: "500",
-  //     fontSize: "32px",
-  //     marginTop: "10px",
-  //     marginBottom: "20px",
-  //   },
-  // },
-  // forVolunteers: {
-  //   padding: "50px 32px 50px",
-  //   margin: "32px 0",
-  //   borderRadius: "24px",
-  //   background: "#B6D8FB",
-  //   display: "flex",
-  //   flexDirection: "column",
-  //   "& $h2": {
-  //     flexBasis: "100%",
-  //     textAlign: "center",
-  //     fontWeight: "500",
-  //     fontSize: "32px",
-  //     marginTop: "10px",
-  //     marginBottom: "20px",
-  //   },
-  // },
-  dl: {
-    marginTop: "10px",
-    marginBottom: "0",
-    "& $dt": {
-      fontWeight: "600",
-      fontSize: "20px",
-    },
-    "& $dd": {
-      marginLeft: "0",
-      marginBottom: "32px",
-    },
-    "& $dd:last-child": {
-      marginBottom: "0",
-    },
-  },
-}));
+// const useStyles = makeStyles(() => ({
+//   // outer: {
+//   //   background: "#fff",
+//   // },
+//   // main: {
+//   //   padding: "1.5rem 0",
+//   //   maxWidth: "1200px",
+//   //   margin: "0 auto",
+//   //   "& $ul": {
+//   //     paddingLeft: "26px",
+//   //     margin: "5px",
+//   //     fontSize: "16px",
+//   //     lineHeight: "26.55px",
+//   //   },
+//   //   "@media only screen and (min-width: 75em)": {
+//   //     padding: "1.5rem 2rem",
+//   //   },
+//   // },
+//   // title: {
+//   //   textTransform: "uppercase",
+//   //   fontWeight: 500,
+//   //   textAlign: "center",
+//   //   background: "#FFF",
+//   //   margin: 0,
+//   //   padding: "32px 0",
+//   //   "& $span": {
+//   //     "& $span": {
+//   //       textTransform: "none",
+//   //     },
+//   //   },
+//   // },
+//   // figure: {
+//   //   margin: 0,
+//   //   padding: 0,
+//   // },
+//   // icon: {
+//   //   margin: "auto",
+//   //   marginBottom: "20px",
+//   // },
+//   // glossary: {
+//   //   padding: "50px 32px 50px",
+//   //   margin: "32px 0",
+//   //   borderRadius: "24px",
+//   //   background: "#f0f0f0",
+//   //   display: "flex",
+//   //   flexWrap: "wrap",
+//   //   "& $h2": {
+//   //     flexBasis: "100%",
+//   //     textAlign: "center",
+//   //     fontWeight: "500",
+//   //     fontSize: "32px",
+//   //     marginTop: "10px",
+//   //     marginBottom: "20px",
+//   //   },
+//   // },
+//   // forVolunteers: {
+//   //   padding: "50px 32px 50px",
+//   //   margin: "32px 0",
+//   //   borderRadius: "24px",
+//   //   background: "#B6D8FB",
+//   //   display: "flex",
+//   //   flexDirection: "column",
+//   //   "& $h2": {
+//   //     flexBasis: "100%",
+//   //     textAlign: "center",
+//   //     fontWeight: "500",
+//   //     fontSize: "32px",
+//   //     marginTop: "10px",
+//   //     marginBottom: "20px",
+//   //   },
+//   // },
+//   // dl: {
+//   //   marginTop: "10px",
+//   //   marginBottom: "0",
+//   //   "& $dt": {
+//   //     fontWeight: "600",
+//   //     fontSize: "20px",
+//   //   },
+//   //   "& $dd": {
+//   //     marginLeft: "0",
+//   //     marginBottom: "32px",
+//   //   },
+//   //   "& $dd:last-child": {
+//   //     marginBottom: "0",
+//   //   },
+//   // },
+// }));
 const About = () => {
-  const classes = useStyles();
+  // const classes = useStyles();
 
   useEffect(() => {
     analytics.postEvent("visitFaqPage");
   }, []);
 
   return (
-    <Container>
+    <Container
+    sx={{
+      padding: { xs: "1.5rem 0", lg: "1.5rem 2rem"}
+    }}
+    >
       <Container 
       sx={{
-        padding: { xs: "1.5rem 0", lg: "1.5rem 2rem"},
+        padding: { xs: "0", lg: "1.5rem 2rem"},
         margin: "0 auto"
       }}
       maxWidth="1200px"
       >
-        <figure className={classes.figure}>
-          <img alt="FAQ" src={faqbg} style={{ width: "100%" }} />
-        </figure>
-        <Typography variant="h1"
-        sx={{
-          textTransform: "uppercase",
-          textAlign: "center",
-          margin: 0,
-          padding: "32px 0"
-        }}
-        >
-          FAQ
-        </Typography>
-        <Box
-        sx={{
-          padding: "50px 32px 50px",
-          margin: "32px 0",
-          borderRadius: "24px",
-          background: "#f0f0f0",
-          display: "flex",
-          flexWrap: "wrap",
-        }}
-        >
-          <img
-            alt="Glossary"
-            src={iconSpacerGray}
-            className={classes.icon}
-            height="40"
-          />
+      <figure style={{
+        margin: 0,
+        padding: 0
+      }}
+      >
+        <CardMedia component="img" alt="FAQ" src={faqbg} style={{ width: "100%" }}></CardMedia>
+      </figure>
+      <Typography variant="h1"
+      sx={{
+        textTransform: "uppercase",
+        textAlign: "center",
+        margin: 0,
+        padding: "32px 0"
+      }}
+      >
+        FAQ
+      </Typography>
+      <Box
+      sx={{
+        padding: "50px 32px 50px",
+        margin: "32px 0",
+        borderRadius: "24px",
+        background: "#f0f0f0",
+        display: "flex",
+        flexWrap: "wrap",
+      }}
+      >
+      <CardMedia
+      component="svg"
+      sx={{
+        margin: "auto",
+        marginBottom: "20px",
+        height: "40px",
+        width: "90px"
+      }}
+      >
+        <SvgIcon 
+        component={IconSpacerSVG}
+        titleAccess="Glossary"
+      />
+      </CardMedia>
           <Typography variant="h2"
           sx={{
             flexBasis: "100%",
@@ -148,35 +166,50 @@ const About = () => {
           }}
           >Food Seekers</Typography>
           <Container maxWidth="sm">
-            <Box className={classes.dl}>
-              <dl>
-                <dt> How do I use this directory?</dt>
-                <ul>
-                  <li>
+            <Box component="dl"
+            sx={{
+              marginTop: "10px",
+              marginBottom: "0",
+              "& dt": {
+                fontWeight: "600",
+                fontSize: "20"
+              },
+              "& dd": {
+                marginLeft: "0",
+                marginBottom: "24px"
+              },
+              "& dd:last-child": {
+                marginBottom: "0"
+              }
+            }}
+            >
+                <Typography component="dt"> How do I use this directory?</Typography>
+                <Box component="ul">
+                  <Typography variant="body1" component="li">
                     From the “Find Food” page, type in your zip code or address
                     and click “Enter.”
-                  </li>
-                  <li>
+                  </Typography>
+                  <Typography variant="body1" component="li">
                     A list of nearby options, sorted from nearest to farthest,
                     will pop up on the left side of the screen.
-                  </li>
-                  <li>
+                  </Typography>
+                  <Typography variant="body1" component="li">
                     Choose “PANTRIES” or “MEALS” if you would like to filter by
                     type of food resource.
-                  </li>
-                  <li>
+                  </Typography>
+                  <Typography variant="body1" component="li">
                     The “Details” button on an entry provides information like
                     Directions, Hours of Operation and Contact Information for
                     the service.
-                  </li>
-                </ul>
+                  </Typography>
+                </Box>
                 <br />
-                <dt>
+                <Typography component="dt">
                   Does this web-based directory include every resource where I
                   can get free food in Los Angeles County?
-                </dt>
-                <ul>
-                  <li>
+                </Typography>
+                <Box component="ul">
+                  <Typography variant="body1" component="li">
                     No. While our directory is not an exhaustive list of every
                     food resource open to the public in Los Angeles, our
                     volunteers work hard to ensure the information listed is
@@ -185,24 +218,23 @@ const About = () => {
                       use this link
                     </Link>
                     .
-                  </li>
-                </ul>
+                  </Typography>
+                </Box>
                 <br />
-                <dt>
+                <Typography component="dt">
                   What is the difference between a food bank, food pantry and
                   meal program?
-                </dt>
-                <ul>
-                  <li>
+                </Typography>
+                <Box component="ul">
+                  <Typography variant="body1" component="li">
                     Generally, food banks collect donated food and distribute
                     items to food pantries. Food pantries provide free groceries
                     to food seekers. Meal programs provide free cooked meals to
                     food seekers. Many locations provide multiple services. Our
                     updated directory indicates which services are available at
                     each location.
-                  </li>
-                </ul>
-              </dl>
+                  </Typography>
+                </Box>
             </Box>
           </Container>
         </Box>
@@ -216,12 +248,20 @@ const About = () => {
           flexDirection: "column"
         }}
         >
-          <img
-            alt="For Volunteers"
-            src={iconSpacerGray}
-            className={classes.icon}
-            height="40"
-          />
+          <CardMedia
+        component="svg"
+        sx={{
+          margin: "auto",
+          marginBottom: "20px",
+          height: "40px",
+          width: "90px"
+        }}
+      >
+        <SvgIcon 
+        component={IconSpacerSVG}
+        titleAccess="Glossary"
+        />
+      </CardMedia>
           <Typography variant="h2"
           sx={{
             flexBasis: "100%",
@@ -231,16 +271,21 @@ const About = () => {
           }}
           >Food Providers</Typography>
           <Container maxWidth="sm">
-            <Typography variant="body1" align="center" className={classes.dl}>
-              <dt>How can I add our food resource to your directory?</dt>
-              <dd>
+            <Box component="dl" align="center">
+              <Typography
+              sx={{
+                fontWeight: "600",
+                fontSize: "20"
+              }}
+              component="dt">How can I add our food resource to your directory?</Typography>
+              <Typography component="dd">
                 Please visit our “
                 <Link to={"/suggestion"} component={RouterLink}>
                   Suggest New Listing
                 </Link>
                 ” page.
-              </dd>
-            </Typography>
+              </Typography>
+            </Box>
           </Container>
         </Box>
         <Footer />

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import faqbg from "./assets/faq-bg.webp";
 // import iconSpacerGray from "./assets/icon-spacer-gray.svg";
 import IconSpacerSVG from "./assets/IconSpacerSVG";
-import { Link, Typography, Container, Box, CardMedia, SvgIcon } from "@mui/material";
+import { Link, Typography, Container, Box, CardMedia, SvgIcon} from "@mui/material";
 // import makeStyles from "@mui/styles/makeStyles";
 import * as analytics from "../../services/analytics";
 import { Link as RouterLink } from "react-router-dom";
@@ -116,13 +116,7 @@ const About = () => {
         maxWidth: "1200px"
       }}
       >
-      <figure style={{
-        margin: 0,
-        padding: 0
-      }}
-      >
-        <CardMedia component="img" alt="FAQ" src={faqbg} style={{ width: "100%" }}></CardMedia>
-      </figure>
+      <CardMedia component="img" alt="FAQ" src={faqbg} style={{ width: "100%" }}></CardMedia>
       <Typography variant="h1"
       sx={{
         textTransform: "uppercase",
@@ -180,7 +174,12 @@ const About = () => {
             }}
             >
                 <Typography variant="subtitle1" component="dt"> How do I use this directory?</Typography>
-                <Box sx={{ paddingLeft: "26px"}} component="ul">
+                <Box 
+                sx={{ 
+                  paddingLeft: "26px",
+                  margin: "5px",
+                  lineHeight: "26.55px"
+                  }} component="ul">
                   <Typography variant="body1" component="li">
                     From the “Find Food” page, type in your zip code or address
                     and click “Enter.”
@@ -204,7 +203,13 @@ const About = () => {
                   Does this web-based directory include every resource where I
                   can get free food in Los Angeles County?
                 </Typography>
-                <Box sx={{ paddingLeft: "26px"}} component="ul">
+                <Box
+                sx={{ 
+                  paddingLeft: "26px",
+                  margin: "5px",
+                  lineHeight: "26.55px"
+                }}
+                 component="ul">
                   <Typography variant="body1" component="li">
                     No. While our directory is not an exhaustive list of every
                     food resource open to the public in Los Angeles, our
@@ -221,7 +226,13 @@ const About = () => {
                   What is the difference between a food bank, food pantry and
                   meal program?
                 </Typography>
-                <Box sx={{ paddingLeft: "26px"}} component="ul">
+                <Box
+                sx={{ 
+                  paddingLeft: "26px",
+                  margin: "5px",
+                  lineHeight: "26.55px"
+                }}
+                component="ul">
                   <Typography variant="body1" component="li">
                     Generally, food banks collect donated food and distribute
                     items to food pantries. Food pantries provide free groceries

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -17,7 +17,7 @@ const About = () => {
   return (
       <Container 
       sx={{
-        padding: { xs: "1.5rem 0", md: "0rem 2rem"},
+        padding: { xs: "1.5rem 0", md: "1.5rem 2rem"},
         margin: "0 auto",
         maxWidth: "1200px"
       }}

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -7,7 +7,6 @@ import { Link, Typography, Container, Box, CardMedia, SvgIcon} from "@mui/materi
 import * as analytics from "../../services/analytics";
 import { Link as RouterLink } from "react-router-dom";
 import Footer from "../Layout/Footer";
-import { height } from "@mui/system";
 
 // const useStyles = makeStyles(() => ({
 //   // outer: {
@@ -111,7 +110,7 @@ const About = () => {
     >
       <Container 
       sx={{
-        padding: { sm: "0", md: "0rem 2rem"},
+        padding: { xs: "0", md: "0rem 2rem"},
         margin: "0 auto",
         maxWidth: "1200px"
       }}

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -1,44 +1,43 @@
 import React, { useEffect } from "react";
 import faqbg from "./assets/faq-bg.webp";
 import iconSpacerGray from "./assets/icon-spacer-gray.svg";
-import { Link, Typography } from "@mui/material";
+import { Link, Typography, Container, Box } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import * as analytics from "../../services/analytics";
-import Container from "@mui/material/Container";
 import { Link as RouterLink } from "react-router-dom";
 import Footer from "../Layout/Footer";
 
 const useStyles = makeStyles(() => ({
-  outer: {
-    background: "#fff",
-  },
-  main: {
-    padding: "1.5rem 0",
-    maxWidth: "1200px",
-    margin: "0 auto",
-    "& $ul": {
-      paddingLeft: "26px",
-      margin: "5px",
-      fontSize: "16px",
-      lineHeight: "26.55px",
-    },
-    "@media only screen and (min-width: 75em)": {
-      padding: "1.5rem 2rem",
-    },
-  },
-  title: {
-    textTransform: "uppercase",
-    fontWeight: 500,
-    textAlign: "center",
-    background: "#FFF",
-    margin: 0,
-    padding: "32px 0",
-    "& $span": {
-      "& $span": {
-        textTransform: "none",
-      },
-    },
-  },
+  // outer: {
+  //   background: "#fff",
+  // },
+  // main: {
+  //   padding: "1.5rem 0",
+  //   maxWidth: "1200px",
+  //   margin: "0 auto",
+  //   "& $ul": {
+  //     paddingLeft: "26px",
+  //     margin: "5px",
+  //     fontSize: "16px",
+  //     lineHeight: "26.55px",
+  //   },
+  //   "@media only screen and (min-width: 75em)": {
+  //     padding: "1.5rem 2rem",
+  //   },
+  // },
+  // title: {
+  //   textTransform: "uppercase",
+  //   fontWeight: 500,
+  //   textAlign: "center",
+  //   background: "#FFF",
+  //   margin: 0,
+  //   padding: "32px 0",
+  //   "& $span": {
+  //     "& $span": {
+  //       textTransform: "none",
+  //     },
+  //   },
+  // },
   figure: {
     margin: 0,
     padding: 0,
@@ -47,38 +46,38 @@ const useStyles = makeStyles(() => ({
     margin: "auto",
     marginBottom: "20px",
   },
-  glossary: {
-    padding: "50px 32px 50px",
-    margin: "32px 0",
-    borderRadius: "24px",
-    background: "#f0f0f0",
-    display: "flex",
-    flexWrap: "wrap",
-    "& $h2": {
-      flexBasis: "100%",
-      textAlign: "center",
-      fontWeight: "500",
-      fontSize: "32px",
-      marginTop: "10px",
-      marginBottom: "20px",
-    },
-  },
-  forVolunteers: {
-    padding: "50px 32px 50px",
-    margin: "32px 0",
-    borderRadius: "24px",
-    background: "#B6D8FB",
-    display: "flex",
-    flexDirection: "column",
-    "& $h2": {
-      flexBasis: "100%",
-      textAlign: "center",
-      fontWeight: "500",
-      fontSize: "32px",
-      marginTop: "10px",
-      marginBottom: "20px",
-    },
-  },
+  // glossary: {
+  //   padding: "50px 32px 50px",
+  //   margin: "32px 0",
+  //   borderRadius: "24px",
+  //   background: "#f0f0f0",
+  //   display: "flex",
+  //   flexWrap: "wrap",
+  //   "& $h2": {
+  //     flexBasis: "100%",
+  //     textAlign: "center",
+  //     fontWeight: "500",
+  //     fontSize: "32px",
+  //     marginTop: "10px",
+  //     marginBottom: "20px",
+  //   },
+  // },
+  // forVolunteers: {
+  //   padding: "50px 32px 50px",
+  //   margin: "32px 0",
+  //   borderRadius: "24px",
+  //   background: "#B6D8FB",
+  //   display: "flex",
+  //   flexDirection: "column",
+  //   "& $h2": {
+  //     flexBasis: "100%",
+  //     textAlign: "center",
+  //     fontWeight: "500",
+  //     fontSize: "32px",
+  //     marginTop: "10px",
+  //     marginBottom: "20px",
+  //   },
+  // },
   dl: {
     marginTop: "10px",
     marginBottom: "0",
@@ -103,24 +102,53 @@ const About = () => {
   }, []);
 
   return (
-    <div className={classes.outer}>
-      <div className={classes.main}>
+    <Container>
+      <Container 
+      sx={{
+        padding: { xs: "1.5rem 0", lg: "1.5rem 2rem"},
+        margin: "0 auto"
+      }}
+      maxWidth="1200px"
+      >
         <figure className={classes.figure}>
           <img alt="FAQ" src={faqbg} style={{ width: "100%" }} />
         </figure>
-        <Typography variant="h1" className={classes.title}>
+        <Typography variant="h1"
+        sx={{
+          textTransform: "uppercase",
+          textAlign: "center",
+          margin: 0,
+          padding: "32px 0"
+        }}
+        >
           FAQ
         </Typography>
-        <section className={classes.glossary}>
+        <Box
+        sx={{
+          padding: "50px 32px 50px",
+          margin: "32px 0",
+          borderRadius: "24px",
+          background: "#f0f0f0",
+          display: "flex",
+          flexWrap: "wrap",
+        }}
+        >
           <img
             alt="Glossary"
             src={iconSpacerGray}
             className={classes.icon}
             height="40"
           />
-          <Typography variant="h2">Food Seekers</Typography>
+          <Typography variant="h2"
+          sx={{
+            flexBasis: "100%",
+            textAlign: "center",
+            marginTop: "10px",
+            marginBottom: "20px"
+          }}
+          >Food Seekers</Typography>
           <Container maxWidth="sm">
-            <div className={classes.dl}>
+            <Box className={classes.dl}>
               <dl>
                 <dt> How do I use this directory?</dt>
                 <ul>
@@ -175,17 +203,33 @@ const About = () => {
                   </li>
                 </ul>
               </dl>
-            </div>
+            </Box>
           </Container>
-        </section>
-        <section className={classes.forVolunteers}>
+        </Box>
+        <Box
+        sx={{
+          padding: "50px 32px 50px",
+          margin: "32px 0",
+          borderRadius: "24px",
+          background: "#B6D8FB",
+          display: "flex",
+          flexDirection: "column"
+        }}
+        >
           <img
             alt="For Volunteers"
             src={iconSpacerGray}
             className={classes.icon}
             height="40"
           />
-          <Typography variant="h2">Food Providers</Typography>
+          <Typography variant="h2"
+          sx={{
+            flexBasis: "100%",
+            textAlign: "center",
+            marginTop: "10px",
+            marginBottom: "20px",
+          }}
+          >Food Providers</Typography>
           <Container maxWidth="sm">
             <Typography variant="body1" align="center" className={classes.dl}>
               <dt>How can I add our food resource to your directory?</dt>
@@ -198,10 +242,10 @@ const About = () => {
               </dd>
             </Typography>
           </Container>
-        </section>
+        </Box>
         <Footer />
-      </div>
-    </div>
+      </Container>
+    </Container>
   );
 };
 

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -170,10 +170,6 @@ const About = () => {
             sx={{
               marginTop: "10px",
               marginBottom: "0",
-              "& dt": {
-                fontWeight: "600",
-                fontSize: "20"
-              },
               "& dd": {
                 marginLeft: "0",
                 marginBottom: "24px"
@@ -183,8 +179,8 @@ const About = () => {
               }
             }}
             >
-                <Typography component="dt"> How do I use this directory?</Typography>
-                <Box component="ul">
+                <Typography variant="subtitle1" component="dt"> How do I use this directory?</Typography>
+                <Box sx={{ paddingLeft: "26px"}} component="ul">
                   <Typography variant="body1" component="li">
                     From the “Find Food” page, type in your zip code or address
                     and click “Enter.”
@@ -204,11 +200,11 @@ const About = () => {
                   </Typography>
                 </Box>
                 <br />
-                <Typography component="dt">
+                <Typography variant="subtitle1" component="dt">
                   Does this web-based directory include every resource where I
                   can get free food in Los Angeles County?
                 </Typography>
-                <Box component="ul">
+                <Box sx={{ paddingLeft: "26px"}} component="ul">
                   <Typography variant="body1" component="li">
                     No. While our directory is not an exhaustive list of every
                     food resource open to the public in Los Angeles, our
@@ -221,11 +217,11 @@ const About = () => {
                   </Typography>
                 </Box>
                 <br />
-                <Typography component="dt">
+                <Typography variant="subtitle1" component="dt">
                   What is the difference between a food bank, food pantry and
                   meal program?
                 </Typography>
-                <Box component="ul">
+                <Box sx={{ paddingLeft: "26px"}} component="ul">
                   <Typography variant="body1" component="li">
                     Generally, food banks collect donated food and distribute
                     items to food pantries. Food pantries provide free groceries
@@ -272,12 +268,7 @@ const About = () => {
           >Food Providers</Typography>
           <Container maxWidth="sm">
             <Box component="dl" align="center">
-              <Typography
-              sx={{
-                fontWeight: "600",
-                fontSize: "20"
-              }}
-              component="dt">How can I add our food resource to your directory?</Typography>
+              <Typography variant="subtitle1" component="dt">How can I add our food resource to your directory?</Typography>
               <Typography component="dd">
                 Please visit our “
                 <Link to={"/suggestion"} component={RouterLink}>

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -1,102 +1,14 @@
 import React, { useEffect } from "react";
 import faqbg from "./assets/faq-bg.webp";
-// import iconSpacerGray from "./assets/icon-spacer-gray.svg";
 import IconSpacerSVG from "./assets/IconSpacerSVG";
 import { Link, Typography, Container, Box, CardMedia, SvgIcon} from "@mui/material";
-// import makeStyles from "@mui/styles/makeStyles";
 import * as analytics from "../../services/analytics";
 import { Link as RouterLink } from "react-router-dom";
 import Footer from "../Layout/Footer";
 
-// const useStyles = makeStyles(() => ({
-//   // outer: {
-//   //   background: "#fff",
-//   // },
-//   // main: {
-//   //   padding: "1.5rem 0",
-//   //   maxWidth: "1200px",
-//   //   margin: "0 auto",
-//   //   "& $ul": {
-//   //     paddingLeft: "26px",
-//   //     margin: "5px",
-//   //     fontSize: "16px",
-//   //     lineHeight: "26.55px",
-//   //   },
-//   //   "@media only screen and (min-width: 75em)": {
-//   //     padding: "1.5rem 2rem",
-//   //   },
-//   // },
-//   // title: {
-//   //   textTransform: "uppercase",
-//   //   fontWeight: 500,
-//   //   textAlign: "center",
-//   //   background: "#FFF",
-//   //   margin: 0,
-//   //   padding: "32px 0",
-//   //   "& $span": {
-//   //     "& $span": {
-//   //       textTransform: "none",
-//   //     },
-//   //   },
-//   // },
-//   // figure: {
-//   //   margin: 0,
-//   //   padding: 0,
-//   // },
-//   // icon: {
-//   //   margin: "auto",
-//   //   marginBottom: "20px",
-//   // },
-//   // glossary: {
-//   //   padding: "50px 32px 50px",
-//   //   margin: "32px 0",
-//   //   borderRadius: "24px",
-//   //   background: "#f0f0f0",
-//   //   display: "flex",
-//   //   flexWrap: "wrap",
-//   //   "& $h2": {
-//   //     flexBasis: "100%",
-//   //     textAlign: "center",
-//   //     fontWeight: "500",
-//   //     fontSize: "32px",
-//   //     marginTop: "10px",
-//   //     marginBottom: "20px",
-//   //   },
-//   // },
-//   // forVolunteers: {
-//   //   padding: "50px 32px 50px",
-//   //   margin: "32px 0",
-//   //   borderRadius: "24px",
-//   //   background: "#B6D8FB",
-//   //   display: "flex",
-//   //   flexDirection: "column",
-//   //   "& $h2": {
-//   //     flexBasis: "100%",
-//   //     textAlign: "center",
-//   //     fontWeight: "500",
-//   //     fontSize: "32px",
-//   //     marginTop: "10px",
-//   //     marginBottom: "20px",
-//   //   },
-//   // },
-//   // dl: {
-//   //   marginTop: "10px",
-//   //   marginBottom: "0",
-//   //   "& $dt": {
-//   //     fontWeight: "600",
-//   //     fontSize: "20px",
-//   //   },
-//   //   "& $dd": {
-//   //     marginLeft: "0",
-//   //     marginBottom: "32px",
-//   //   },
-//   //   "& $dd:last-child": {
-//   //     marginBottom: "0",
-//   //   },
-//   // },
-// }));
+
+
 const About = () => {
-  // const classes = useStyles();
 
   useEffect(() => {
     analytics.postEvent("visitFaqPage");

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from "react";
 import faqbg from "./assets/faq-bg.webp";
-import iconSpacerGray from "./assets/icon-spacer-gray.svg";
+// import iconSpacerGray from "./assets/icon-spacer-gray.svg";
 import IconSpacerSVG from "./assets/IconSpacerSVG";
 import { Link, Typography, Container, Box, CardMedia, SvgIcon } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+// import makeStyles from "@mui/styles/makeStyles";
 import * as analytics from "../../services/analytics";
 import { Link as RouterLink } from "react-router-dom";
 import Footer from "../Layout/Footer";
@@ -106,15 +106,15 @@ const About = () => {
   return (
     <Container
     sx={{
-      padding: { xs: "1.5rem 0", lg: "1.5rem 2rem"}
+      padding: { xs: "1.5rem 0" },
     }}
     >
       <Container 
       sx={{
-        padding: { xs: "0", lg: "1.5rem 2rem"},
-        margin: "0 auto"
+        padding: { sm: "0", md: "0rem 2rem"},
+        margin: "0 auto",
+        maxWidth: "1200px"
       }}
-      maxWidth="1200px"
       >
       <figure style={{
         margin: 0,

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -15,14 +15,9 @@ const About = () => {
   }, []);
 
   return (
-    <Container
-    sx={{
-      padding: { xs: "1.5rem 0" },
-    }}
-    >
       <Container 
       sx={{
-        padding: { xs: "0", md: "0rem 2rem"},
+        padding: { xs: "1.5rem 0", md: "0rem 2rem"},
         margin: "0 auto",
         maxWidth: "1200px"
       }}
@@ -203,7 +198,6 @@ const About = () => {
         </Box>
         <Footer />
       </Container>
-    </Container>
   );
 };
 

--- a/client/src/components/StaticPages/assets/IconSpacerSVG.js
+++ b/client/src/components/StaticPages/assets/IconSpacerSVG.js
@@ -1,0 +1,7 @@
+
+
+const IconSpacerSVG = () => {
+    return <svg fill="none" height="100%" viewBox="0 0 90 41" width="100%" xmlns="http://www.w3.org/2000/svg"><path d="m0 40h90" stroke="#4d4d4d" stroke-width="2"/><path clip-rule="evenodd" d="m45 33s-12-14.5126-12-21.0902c0-6.57761 5.3726-11.9098 12-11.9098s12 5.33219 12 11.9098c0 6.5776-12 21.0902-12 21.0902zm0-15.8797c-3.3137 0-6-2.6661-6-5.9549 0-3.28878 2.6863-5.95487 6-5.95487s6 2.66609 6 5.95487c0 3.2888-2.6863 5.9549-6 5.9549z" fill="#4d4d4d" fill-rule="evenodd"/></svg>
+}
+
+export default IconSpacerSVG


### PR DESCRIPTION
Fixes #1705

- Replaced HTML with Material-UI Components
- Added styles in `sx` prop
- Added `variants` to Typography components to follow override themes and have a consistent styling
- Used breakpoints instead of `@meadia query px` to follow project themes and have a consistent styling
- Removed `<figure>` element and added `component="img"` to CardMedia to ensure accessibility
- Changed `<dt> <dl> and <dd>` elements for `<Box>` with component prop
- Removed `makeStyles` function and unused elements and imports
- Added React Component that returns SVG icon in `assests/IconSpacerSVG.js` so I can use Material-UI's SVGIcon correctly
- I used a screen reader to make sure it works as before despite the changes in the HTML
_Some breakpoints, measures and font-sizes changed slightly by using variants and provided breakpoints, but these will end up matching in the whole project once all the styles are updated. Using theses provided styles will facilitate future maintenance and styling of the website._

<details><summary>Video of current Web Page</summary>

> https://github.com/hackforla/food-oasis/assets/98275292/c43410df-7aad-4c70-aef7-2e544f3d45f7

</details>

<details><summary>Video after changes</summary>

> https://github.com/hackforla/food-oasis/assets/98275292/f51dacec-a64f-40a0-905e-e9a30a845e7a

</details>
