### PR TITLE
Found Bug in Links color

### DIFF
--- a/client/src/components/StaticPages/About.js
+++ b/client/src/components/StaticPages/About.js
@@ -194,6 +194,7 @@ const About = () => {
             <Typography variant="body1">
               We are a 100% volunteer-run project. We are part of{" "}
               <Link
+                variant="primary"
                 href="https://hackforla.org/"
                 target={"_blank"}
                 rel="noopener noreferrer"
@@ -218,7 +219,7 @@ const About = () => {
           <Typography variant="h2">Questions</Typography>
           <Typography variant="body1">
             For more information, please visit our{" "}
-            <Link to={"/faqs"} component={RouterLink}>
+            <Link variant="primary" to={"/faqs"} component={RouterLink}>
               FAQ page
             </Link>
             .
@@ -245,6 +246,7 @@ const About = () => {
               Please contact our Support Team
               <br />
               <Link
+                variant="primary"
                 href="mailto:foodoasisinfo@hackforla.org"
               >
                 foodoasisinfo@hackforla.org

--- a/client/src/components/StaticPages/Faq.js
+++ b/client/src/components/StaticPages/Faq.js
@@ -153,7 +153,7 @@ const About = () => {
                     food resource open to the public in Los Angeles, our
                     volunteers work hard to ensure the information listed is
                     updated. To suggest a listing missing from our directory,{" "}
-                    <Link to={"/suggestion"} component={RouterLink}>
+                    <Link variant="primary" to={"/suggestion"} component={RouterLink}>
                       use this link
                     </Link>
                     .
@@ -191,7 +191,7 @@ const About = () => {
               <dt>How can I add our food resource to your directory?</dt>
               <dd>
                 Please visit our “
-                <Link to={"/suggestion"} component={RouterLink}>
+                <Link variant="primary" to={"/suggestion"} component={RouterLink}>
                   Suggest New Listing
                 </Link>
                 ” page.

--- a/client/src/theme/overrides/Link.js
+++ b/client/src/theme/overrides/Link.js
@@ -9,6 +9,9 @@
 export default function Link(theme) {
   return {
     MuiLink: {
+      defaultProps: {
+        default: "primary"
+      },
       variants: [
         {
           props: { variant: "icon" },

--- a/client/src/theme/overrides/Link.js
+++ b/client/src/theme/overrides/Link.js
@@ -16,26 +16,30 @@ export default function Link(theme) {
             textDecoration: "none",
           },
         },
-      ],
-      styleOverrides: {
-        inherit: {
+        {
+          props: { variant: "primary" },
+          style: {
           textDecoration: "none",
           padding: "2px 1px 0",
           borderBottom: "1px solid",
           "&:link": {
             color: theme.palette.link.normal,
           },
-          "&:visited": {
-            color: theme.palette.link.visited,
+          "&:a": {
+            color: theme.palette.link.normal,
           },
-          "&:hover": {
-            color: theme.palette.link.hovered,
-          },
-          "&:active": {
-            color: theme.palette.primary.light,
+          // "&:visited": {
+          //   color: theme.palette.link.visited,
+          // },
+          // "&:hover": {
+          //   color: theme.palette.link.hovered,
+          // },
+          // "&:active": {
+          //   color: theme.palette.primary.light,
+          // },
           },
         },
-      },
+      ],
     },
   };
 }

--- a/client/src/theme/overrides/Link.js
+++ b/client/src/theme/overrides/Link.js
@@ -28,15 +28,15 @@ export default function Link(theme) {
           "&:a": {
             color: theme.palette.link.normal,
           },
-          // "&:visited": {
-          //   color: theme.palette.link.visited,
-          // },
-          // "&:hover": {
-          //   color: theme.palette.link.hovered,
-          // },
-          // "&:active": {
-          //   color: theme.palette.primary.light,
-          // },
+          "&:visited": {
+            color: theme.palette.link.visited,
+          },
+          "&:hover": {
+            color: theme.palette.link.hovered,
+          },
+          "&:active": {
+            color: theme.palette.primary.light,
+          },
           },
         },
       ],


### PR DESCRIPTION
Fixes #1709 

The bug was located in `theme/overrides/Link.js`. The variants applied to the Links were the ones intended for the Typography.

The MUI docs for Link say that 

> inherit Applies the theme typography styles.
https://mui.com/material-ui/api/link/

I am not familiar with the Overrides in MUI but by changing the overrides and adding the desired styles in a new variant, the color was corrected.
I also added the variant to a few links. We might need to make another Issue to find all the Links that need to have the new "primary" variant added.

<details><summary>Link color before my changes</summary

![before changes color](https://github.com/hackforla/food-oasis/assets/98275292/2644abd7-bc84-4eaa-8fab-cf6d7e7806ce)

</details>

<details><summary>Link color after my changes</summary>

![after changes color](https://github.com/hackforla/food-oasis/assets/98275292/388640d1-b60f-4520-8f2b-4c831398ef2d)


</details>


