### PR TITLE
changed default with variant

### DIFF
--- a/client/src/theme/overrides/Link.js
+++ b/client/src/theme/overrides/Link.js
@@ -10,7 +10,7 @@ export default function Link(theme) {
   return {
     MuiLink: {
       defaultProps: {
-        default: "primary"
+        variant: "primary"
       },
       variants: [
         {

--- a/client/src/theme/overrides/Link.js
+++ b/client/src/theme/overrides/Link.js
@@ -25,6 +25,7 @@ export default function Link(theme) {
           textDecoration: "none",
           padding: "2px 1px 0",
           borderBottom: "1px solid",
+          color: theme.palette.link.normal,
           "&:link": {
             color: theme.palette.link.normal,
           },


### PR DESCRIPTION
Fixed mistake made in the changes yesterday. Changed "default" with "variant" in Link's overrides styles. This is part of this https://github.com/hackforla/food-oasis/pull/1713#discussion_r1227484632 conversation
