### PR TITLE
Add global hover effect to checkboxes

### DIFF
--- a/client/src/theme/overrides/Checkbox.js
+++ b/client/src/theme/overrides/Checkbox.js
@@ -14,6 +14,9 @@ export default function Checkbox(theme) {
             borderWidth: "2px",
             borderRadius: "4px",
           },
+        "&:hover": {
+          backgroundColor: "rgba(51, 102, 153, 0.2)",
+          },
         },
       },
     },


### PR DESCRIPTION
- Closes Issue  #1719 
- I added to the theme/overrides file for checkboxes to change the hover state background color

## Screenshots

### Figma screenshot:
<img width="213" alt="Screen Shot 2023-06-13 at 5 32 59 PM" src="https://github.com/hackforla/food-oasis/assets/8907997/9583bc5b-6f4d-4dfc-b973-f7a5bccaf978">

### After changes:
<img width="253" alt="Screen Shot 2023-06-13 at 5 33 21 PM" src="https://github.com/hackforla/food-oasis/assets/8907997/3aed684e-643d-46de-85fe-804b344f45ae">

### the tooltip's background color
- I did not change this- just noting that the background colors on hover are now different
<img width="151" alt="Screen Shot 2023-06-13 at 5 33 32 PM" src="https://github.com/hackforla/food-oasis/assets/8907997/a8726801-81db-4ed7-80b3-909018705105">

