### PR TITLE
Update Styling System to Use xs Prop in Material-UI Components in CorrectionDialog.js

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/CorrectionDialog.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/CorrectionDialog.js
@@ -52,12 +52,6 @@ function SuggestionDialog(props) {
                 <Label id="notes" label="Corrections *" />
                 <Textarea
                   type="text"
-                  sx={{
-                    "& div": {
-                    "& textarea": {
-                      paddingRight: "2rem",
-                    },
-                  },}}
                   size="small"
                   minRows={2}
                   maxRows={12}

--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/CorrectionDialog.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/CorrectionDialog.js
@@ -11,28 +11,17 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
 import * as suggestionService from "services/suggestion-service";
 import { DEFAULT_STAKEHOLDER } from "../../../../constants/stakeholder";
 import * as Yup from "yup";
 import Label from "components/Admin/ui/Label";
 import Textarea from "components/Admin/ui/Textarea";
 
-const useStyles = makeStyles((theme) => ({
-  correctionInput: {
-    "& div": {
-      "& textarea": {
-        paddingRight: "2rem",
-      },
-    },
-  },
-}));
 function SuggestionDialog(props) {
   const { values, touched, errors, handleChange, handleBlur, handleSubmit } =
     props;
 
   const { onClose, open, id } = props;
-  const classes = useStyles();
   const handleCancel = () => onClose(false);
 
   return (
@@ -63,7 +52,12 @@ function SuggestionDialog(props) {
                 <Label id="notes" label="Corrections *" />
                 <Textarea
                   type="text"
-                  className={classes.correctionInput}
+                  sx={{
+                    "& div": {
+                    "& textarea": {
+                      paddingRight: "2rem",
+                    },
+                  },}}
                   size="small"
                   minRows={2}
                   maxRows={12}


### PR DESCRIPTION
- Resolved the styling for the CorrectionDialog.js to align with Material-UI version 5. 

- CorrectionDialog.js before image 
![before-image](https://github.com/hackforla/food-oasis/assets/101593133/b9f4b4dd-062b-4c85-b53f-9e74e54cff8b)

-  CorrectionDialog.js after image 
![after-image](https://github.com/hackforla/food-oasis/assets/101593133/5f6e4084-1af4-43e3-a771-3e90ca475331)
