### PR TITLE
Update styling to use sx prop verification admin 1833

### DIFF
--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -29,54 +29,7 @@ import { AddBoxOutlined, GifBox, GifBoxTwoTone } from '@mui/icons-material';
 
 const CRITERIA_TOKEN = 'verificationAdminCriteria';
 
-const useStyles = makeStyles((theme) => ({
-  // root: {
-  //   flexGrow: 1,
-  //   flexBasis: '100%',
-  //   display: 'flex',
-  //   flexDirection: 'column',
-  //   padding: '2rem',
-  //   paddingBottom: '0',
-  // },
-  // mainContent: {
-  //   flexGrow: 1,
-  //   padding: theme.spacing(2),
-  //   display: 'flex',
-  //   flexDirection: 'column',
-  // },
-  closeButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-    // color: theme.palette.grey[500],
-  },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  menuButton: {
-    marginRight: theme.spacing(2),
-  },
-  hide: {
-    display: 'none',
-  },
-  bigMessage: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    backgroundColor: '#E8E8E8',
-    textAlign: 'center',
-    padding: '4em',
-  },
-  errorText: {
-    color: theme.palette.error.main,
-    fontSize: '24pt',
-  },
-}));
-
 const DialogTitle = (props) => {
-  const classes = useStyles();
   const { children, onClose, ...other } = props;
   return (
     <MuiDialogTitle
@@ -144,7 +97,6 @@ const defaultCriteria = {
 
 function VerificationAdmin() {
   const { user } = useUserContext();
-  const classes = useStyles();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [needsVerificationDialogOpen, setNeedsVerificationDialogOpen] =

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -5,6 +5,7 @@ import { Button, CssBaseline, Dialog, Typography } from "@mui/material";
 import Stack from "@mui/material/Stack";
 import MuiDialogTitle from "@mui/material/DialogTitle";
 import makeStyles from "@mui/styles/makeStyles";
+import Box from "@mui/material/Box";
 import { useOrganizations } from "hooks/useOrganizations";
 import { useCategories } from "hooks/useCategories";
 import { useNeighborhoods } from "hooks/useNeighborhoods";

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -1,75 +1,75 @@
-import React, { useState, useEffect } from "react";
-import PropTypes from "prop-types";
-import { useLocation, useNavigate } from "react-router-dom";
-import { Button, CssBaseline, Dialog, Typography } from "@mui/material";
-import Stack from "@mui/material/Stack";
-import MuiDialogTitle from "@mui/material/DialogTitle";
-import makeStyles from "@mui/styles/makeStyles";
-import Box from "@mui/material/Box";
-import { useOrganizations } from "hooks/useOrganizations";
-import { useCategories } from "hooks/useCategories";
-import { useNeighborhoods } from "hooks/useNeighborhoods";
-import { useTags } from "hooks/useTags";
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button, CssBaseline, Dialog, Typography } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import MuiDialogTitle from '@mui/material/DialogTitle';
+import makeStyles from '@mui/styles/makeStyles';
+import Box from '@mui/material/Box';
+import { useOrganizations } from 'hooks/useOrganizations';
+import { useCategories } from 'hooks/useCategories';
+import { useNeighborhoods } from 'hooks/useNeighborhoods';
+import { useTags } from 'hooks/useTags';
 import {
   needsVerification,
   assign,
   exportCsv,
-} from "services/stakeholder-service";
-import AssignDialog from "./AssignDialog";
-import NeedsVerificationDialog from "./ui/NeedsVerificationDialog";
-import SearchCriteria from "./SearchCriteria";
-import SearchCriteriaDisplay from "./SearchCriteriaDisplay";
+} from 'services/stakeholder-service';
+import AssignDialog from './AssignDialog';
+import NeedsVerificationDialog from './ui/NeedsVerificationDialog';
+import SearchCriteria from './SearchCriteria';
+import SearchCriteriaDisplay from './SearchCriteriaDisplay';
 
-import { useUserContext } from "../../contexts/userContext";
-import { useSearchCoordinates, useUserCoordinates } from "../../appReducer";
-import CircularProgress from "@mui/material/CircularProgress";
-import VerificationAdminGridMui from "./VerificationAdminGridMui";
+import { useUserContext } from '../../contexts/userContext';
+import { useSearchCoordinates, useUserCoordinates } from '../../appReducer';
+import CircularProgress from '@mui/material/CircularProgress';
+import VerificationAdminGridMui from './VerificationAdminGridMui';
 
-const CRITERIA_TOKEN = "verificationAdminCriteria";
+const CRITERIA_TOKEN = 'verificationAdminCriteria';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
-    flexBasis: "100%",
-    display: "flex",
-    flexDirection: "column",
-    padding: "2rem",
-    paddingBottom: "0",
+    flexBasis: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '2rem',
+    paddingBottom: '0',
   },
   mainContent: {
     flexGrow: 1,
     padding: theme.spacing(2),
-    display: "flex",
-    flexDirection: "column",
+    display: 'flex',
+    flexDirection: 'column',
   },
   closeButton: {
-    position: "absolute",
+    position: 'absolute',
     right: theme.spacing(1),
     top: theme.spacing(1),
     // color: theme.palette.grey[500],
   },
   header: {
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center",
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   menuButton: {
     marginRight: theme.spacing(2),
   },
   hide: {
-    display: "none",
+    display: 'none',
   },
   bigMessage: {
     flexGrow: 1,
-    flexDirection: "column",
-    justifyContent: "center",
-    backgroundColor: "#E8E8E8",
-    textAlign: "center",
-    padding: "4em",
+    flexDirection: 'column',
+    justifyContent: 'center',
+    backgroundColor: '#E8E8E8',
+    textAlign: 'center',
+    padding: '4em',
   },
   errorText: {
     color: theme.palette.error.main,
-    fontSize: "24pt",
+    fontSize: '24pt',
   },
 }));
 
@@ -78,13 +78,13 @@ const DialogTitle = (props) => {
   const { children, onClose, ...other } = props;
   return (
     <MuiDialogTitle disableTypography className={classes.root} {...other}>
-      <Typography variant="h6">{children}</Typography>
+      <Typography variant='h6'>{children}</Typography>
       {onClose ? (
         <Button
-          variant="contained"
-          type="button"
-          icon="search"
-          kind="close"
+          variant='contained'
+          type='button'
+          icon='search'
+          kind='close'
           onClick={onClose}
           className={classes.closeButton}
         >
@@ -101,27 +101,27 @@ DialogTitle.propTypes = {
 };
 
 const defaultCriteria = {
-  name: "",
+  name: '',
   latitude: 34,
   longitude: -118,
-  placeName: "",
+  placeName: '',
   radius: 0,
   categoryIds: [],
   tags: [],
-  isInactive: "either",
-  isAssigned: "either",
-  isSubmitted: "either",
-  isApproved: "either",
-  isClaimed: "either",
+  isInactive: 'either',
+  isAssigned: 'either',
+  isSubmitted: 'either',
+  isApproved: 'either',
+  isClaimed: 'either',
   assignedLoginId: null,
   claimedLoginId: null,
   verificationStatusId: 0,
   neighborhoodId: 0,
   minCompleteCriticalPercent: 0,
   maxCompleteCriticalPercent: 100,
-  stakeholderId: "",
-  isInactiveTemporary: "either",
-  tag: "",
+  stakeholderId: '',
+  isInactiveTemporary: 'either',
+  tag: '',
 };
 
 function VerificationAdmin() {
@@ -178,7 +178,7 @@ function VerificationAdmin() {
       setCriteria(initialCriteria);
       try {
         await searchCallback(initialCriteria);
-        console.log("executed");
+        console.log('executed');
       } catch (err) {
         // If we receive a 401 status code, the user needs
         // to be logged in, will redirect to login page.
@@ -195,7 +195,7 @@ function VerificationAdmin() {
   const search = async (searchCriteria = criteria) => {
     try {
       await searchCallback(searchCriteria);
-      console.log("Searching...");
+      console.log('Searching...');
       console.log(searchCriteria);
       sessionStorage.setItem(CRITERIA_TOKEN, JSON.stringify(searchCriteria));
     } catch (err) {
@@ -217,7 +217,7 @@ function VerificationAdmin() {
       // to be logged in, will redirect to login page.
       // Otherwise it's a real exception.
       if (err.response && err.response.status === 401) {
-        navigate("/login", { state: { from: location } });
+        navigate('/login', { state: { from: location } });
       } else {
         console.error(err);
         return Promise.reject(err.message);
@@ -243,7 +243,7 @@ function VerificationAdmin() {
       // to be logged in, will redirect to login page.
       // Otherwise it's a real exception.
       if (err.response && err.response.status === 401) {
-        navigate("/login", { state: { from: location } });
+        navigate('/login', { state: { from: location } });
       } else {
         console.error(err);
         return Promise.reject(err.message);
@@ -275,7 +275,7 @@ function VerificationAdmin() {
       // to be logged in, will redirect to login page.
       // Otherwise it's a real exception.
       if (err.response && err.response.status === 401) {
-        navigate("/login", { state: { from: location } });
+        navigate('/login', { state: { from: location } });
       } else {
         console.error(err);
         return Promise.reject(err.message);
@@ -306,30 +306,36 @@ function VerificationAdmin() {
       <CssBaseline />
       <div
         style={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          margin: "10px",
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          margin: '10px',
         }}
       >
-        <header className={classes.header}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
           <Typography
-            variant="h2"
-            component="h2"
-            align="center"
-            style={{ marginBottom: "0.5em" }}
+            variant='h2'
+            component='h2'
+            align='center'
+            style={{ marginBottom: '0.5em' }}
           >
             Verification Administration
           </Typography>
           <Button
-            variant="contained"
-            type="button"
-            icon="search"
+            variant='contained'
+            type='button'
+            icon='search'
             onClick={handleDialogOpen}
           >
             Criteria...
           </Button>
-        </header>
+        </Box>
       </div>
       <SearchCriteriaDisplay
         defaultCriteria={defaultCriteria}
@@ -346,11 +352,11 @@ function VerificationAdmin() {
           open={dialogOpen}
           onClose={handleDialogClose}
           fullWidth
-          maxWidth="lg"
+          maxWidth='lg'
         >
           <DialogTitle onClose={handleDialogClose}>Search Criteria</DialogTitle>
           {criteria ? (
-            <div style={{ overflowY: "scroll" }}>
+            <div style={{ overflowY: 'scroll' }}>
               <SearchCriteria
                 key={JSON.stringify({
                   userLatitude:
@@ -382,28 +388,28 @@ function VerificationAdmin() {
             tagsLoading ? (
             <div
               style={{
-                height: "200",
-                width: "100%",
-                margin: "100px auto",
-                display: "flex",
-                justifyContent: "space-around",
+                height: '200',
+                width: '100%',
+                margin: '100px auto',
+                display: 'flex',
+                justifyContent: 'space-around',
               }}
-              aria-label="Loading spinner"
+              aria-label='Loading spinner'
             >
               <CircularProgress />
             </div>
           ) : null}
         </Dialog>
         <AssignDialog
-          id="assign-dialog"
+          id='assign-dialog'
           keepMounted
           open={assignDialogOpen}
           onClose={handleAssignDialogClose}
         />
         <NeedsVerificationDialog
-          id="needs-verification-dialog"
+          id='needs-verification-dialog'
           title='Change Listing(s) Status to "Needs Verification"'
-          message={""}
+          message={''}
           // preserveConfirmations={false}
           open={needsVerificationDialogOpen}
           onClose={handleNeedsVerificationDialogClose}
@@ -412,8 +418,8 @@ function VerificationAdmin() {
           {categoriesError || stakeholdersError || tagsError ? (
             <div className={classes.bigMessage}>
               <Typography
-                variant="h3"
-                component="h3"
+                variant='h3'
+                component='h3'
                 className={classes.errorText}
               >
                 Uh Oh! Something went wrong!
@@ -423,18 +429,18 @@ function VerificationAdmin() {
             <div
               style={{
                 flexGrow: 1,
-                width: "100%",
-                margin: "100px auto",
-                display: "flex",
-                justifyContent: "space-around",
+                width: '100%',
+                margin: '100px auto',
+                display: 'flex',
+                justifyContent: 'space-around',
               }}
-              aria-label="Loading spinner"
+              aria-label='Loading spinner'
             >
               <CircularProgress />
             </div>
           ) : stakeholders && stakeholders.length === 0 ? (
             <div className={classes.bigMessage}>
-              <Typography variant="h5" component="h5">
+              <Typography variant='h5' component='h5'>
                 No matches found, please try different criteria
               </Typography>
             </div>
@@ -442,31 +448,31 @@ function VerificationAdmin() {
             <>
               <div
                 style={{
-                  display: "flex",
-                  flexDirection: "row",
-                  justifyContent: "space-between",
+                  display: 'flex',
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
                 }}
               >
-                <Stack direction="row" spacing={2} marginBottom={1}>
+                <Stack direction='row' spacing={2} marginBottom={1}>
                   <Button
-                    variant="outlined"
-                    type="button"
+                    variant='outlined'
+                    type='button'
                     disabled={selectedStakeholderIds.length === 0}
                     onClick={handleNeedsVerificationDialogOpen}
                   >
                     Needs Verification
                   </Button>
                   <Button
-                    variant="outlined"
-                    type="button"
+                    variant='outlined'
+                    type='button'
                     disabled={selectedStakeholderIds.length === 0}
                     onClick={handleAssignDialogOpen}
                   >
                     Assign
                   </Button>
                   <Button
-                    variant="outlined"
-                    type="button"
+                    variant='outlined'
+                    type='button'
                     disabled={selectedStakeholderIds.length === 0}
                     onClick={handleExport}
                   >
@@ -477,13 +483,13 @@ function VerificationAdmin() {
               </div>
               <VerificationAdminGridMui
                 stakeholders={stakeholders}
-                mode={"admin"}
+                mode={'admin'}
                 setSelectedStakeholderIds={setSelectedStakeholderIds}
               />
             </>
           ) : (
             <div className={classes.bigMessage}>
-              <Typography variant="h5" component="h5">
+              <Typography variant='h5' component='h5'>
                 Please enter search criteria and execute a search
               </Typography>
             </div>

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -1,32 +1,32 @@
-import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { Button, CssBaseline, Dialog, Typography } from '@mui/material';
-import Stack from '@mui/material/Stack';
-import MuiDialogTitle from '@mui/material/DialogTitle';
-import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
-import { useOrganizations } from 'hooks/useOrganizations';
-import { useCategories } from 'hooks/useCategories';
-import { useNeighborhoods } from 'hooks/useNeighborhoods';
-import { useTags } from 'hooks/useTags';
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Button, CssBaseline, Dialog, Typography } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import MuiDialogTitle from "@mui/material/DialogTitle";
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import { useOrganizations } from "hooks/useOrganizations";
+import { useCategories } from "hooks/useCategories";
+import { useNeighborhoods } from "hooks/useNeighborhoods";
+import { useTags } from "hooks/useTags";
 import {
   needsVerification,
   assign,
   exportCsv,
-} from 'services/stakeholder-service';
-import AssignDialog from './AssignDialog';
-import NeedsVerificationDialog from './ui/NeedsVerificationDialog';
-import SearchCriteria from './SearchCriteria';
-import SearchCriteriaDisplay from './SearchCriteriaDisplay';
+} from "services/stakeholder-service";
+import AssignDialog from "./AssignDialog";
+import NeedsVerificationDialog from "./ui/NeedsVerificationDialog";
+import SearchCriteria from "./SearchCriteria";
+import SearchCriteriaDisplay from "./SearchCriteriaDisplay";
 
-import { useUserContext } from '../../contexts/userContext';
-import { useSearchCoordinates, useUserCoordinates } from '../../appReducer';
-import CircularProgress from '@mui/material/CircularProgress';
-import VerificationAdminGridMui from './VerificationAdminGridMui';
-import { AddBoxOutlined, GifBox, GifBoxTwoTone } from '@mui/icons-material';
+import { useUserContext } from "../../contexts/userContext";
+import { useSearchCoordinates, useUserCoordinates } from "../../appReducer";
+import CircularProgress from "@mui/material/CircularProgress";
+import VerificationAdminGridMui from "./VerificationAdminGridMui";
+import { AddBoxOutlined, GifBox, GifBoxTwoTone } from "@mui/icons-material";
 
-const CRITERIA_TOKEN = 'verificationAdminCriteria';
+const CRITERIA_TOKEN = "verificationAdminCriteria";
 
 const DialogTitle = (props) => {
   const { children, onClose, ...other } = props;
@@ -34,27 +34,27 @@ const DialogTitle = (props) => {
     <MuiDialogTitle
       disableTypography
       sx={{
-        flexGrow: '1',
-        flexBasis: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '2rem',
-        paddingBottom: '0',
+        flexGrow: "1",
+        flexBasis: "100%",
+        display: "flex",
+        flexDirection: "column",
+        padding: "2rem",
+        paddingBottom: "0",
       }}
       {...other}
     >
-      <Typography variant='h6'>{children}</Typography>
+      <Typography variant="h6">{children}</Typography>
       {onClose ? (
         <Button
-          variant='contained'
-          type='button'
-          icon='search'
-          kind='close'
+          variant="contained"
+          type="button"
+          icon="search"
+          kind="close"
           onClick={onClose}
           sx={{
-            position: 'absolute',
-            right: '8px',
-            top: '8px',
+            position: "absolute",
+            right: "8px",
+            top: "8px",
           }}
         >
           Search
@@ -70,27 +70,27 @@ DialogTitle.propTypes = {
 };
 
 const defaultCriteria = {
-  name: '',
+  name: "",
   latitude: 34,
   longitude: -118,
-  placeName: '',
+  placeName: "",
   radius: 0,
   categoryIds: [],
   tags: [],
-  isInactive: 'either',
-  isAssigned: 'either',
-  isSubmitted: 'either',
-  isApproved: 'either',
-  isClaimed: 'either',
+  isInactive: "either",
+  isAssigned: "either",
+  isSubmitted: "either",
+  isApproved: "either",
+  isClaimed: "either",
   assignedLoginId: null,
   claimedLoginId: null,
   verificationStatusId: 0,
   neighborhoodId: 0,
   minCompleteCriticalPercent: 0,
   maxCompleteCriticalPercent: 100,
-  stakeholderId: '',
-  isInactiveTemporary: 'either',
-  tag: '',
+  stakeholderId: "",
+  isInactiveTemporary: "either",
+  tag: "",
 };
 
 function VerificationAdmin() {
@@ -146,7 +146,7 @@ function VerificationAdmin() {
       setCriteria(initialCriteria);
       try {
         await searchCallback(initialCriteria);
-        console.log('executed');
+        console.log("executed");
       } catch (err) {
         // If we receive a 401 status code, the user needs
         // to be logged in, will redirect to login page.
@@ -163,7 +163,7 @@ function VerificationAdmin() {
   const search = async (searchCriteria = criteria) => {
     try {
       await searchCallback(searchCriteria);
-      console.log('Searching...');
+      console.log("Searching...");
       console.log(searchCriteria);
       sessionStorage.setItem(CRITERIA_TOKEN, JSON.stringify(searchCriteria));
     } catch (err) {
@@ -185,7 +185,7 @@ function VerificationAdmin() {
       // to be logged in, will redirect to login page.
       // Otherwise it's a real exception.
       if (err.response && err.response.status === 401) {
-        navigate('/login', { state: { from: location } });
+        navigate("/login", { state: { from: location } });
       } else {
         console.error(err);
         return Promise.reject(err.message);
@@ -211,7 +211,7 @@ function VerificationAdmin() {
       // to be logged in, will redirect to login page.
       // Otherwise it's a real exception.
       if (err.response && err.response.status === 401) {
-        navigate('/login', { state: { from: location } });
+        navigate("/login", { state: { from: location } });
       } else {
         console.error(err);
         return Promise.reject(err.message);
@@ -243,7 +243,7 @@ function VerificationAdmin() {
       // to be logged in, will redirect to login page.
       // Otherwise it's a real exception.
       if (err.response && err.response.status === 401) {
-        navigate('/login', { state: { from: location } });
+        navigate("/login", { state: { from: location } });
       } else {
         console.error(err);
         return Promise.reject(err.message);
@@ -272,42 +272,42 @@ function VerificationAdmin() {
   return (
     <Box
       sx={{
-        flexGrow: '1',
-        flexBasis: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '2rem',
-        paddingBottom: '0',
+        flexGrow: "1",
+        flexBasis: "100%",
+        display: "flex",
+        flexDirection: "column",
+        padding: "2rem",
+        paddingBottom: "0",
       }}
     >
       <CssBaseline />
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'space-between',
-          margin: '10px',
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          margin: "10px",
         }}
       >
         <Box
           sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
           <Typography
-            variant='h2'
-            component='h2'
-            align='center'
-            style={{ marginBottom: '0.5em' }}
+            variant="h2"
+            component="h2"
+            align="center"
+            style={{ marginBottom: "0.5em" }}
           >
             Verification Administration
           </Typography>
           <Button
-            variant='contained'
-            type='button'
-            icon='search'
+            variant="contained"
+            type="button"
+            icon="search"
             onClick={handleDialogOpen}
           >
             Criteria...
@@ -326,21 +326,21 @@ function VerificationAdmin() {
       />
       <Box
         sx={{
-          flexGrow: '1',
-          padding: '2',
-          display: 'flex',
-          flexDirection: 'column',
+          flexGrow: "1",
+          padding: "2",
+          display: "flex",
+          flexDirection: "column",
         }}
       >
         <Dialog
           open={dialogOpen}
           onClose={handleDialogClose}
           fullWidth
-          maxWidth='lg'
+          maxWidth="lg"
         >
           <DialogTitle onClose={handleDialogClose}>Search Criteria</DialogTitle>
           {criteria ? (
-            <Box sx={{ overflowY: 'scroll' }}>
+            <Box sx={{ overflowY: "scroll" }}>
               <SearchCriteria
                 key={JSON.stringify({
                   userLatitude:
@@ -372,28 +372,28 @@ function VerificationAdmin() {
             tagsLoading ? (
             <Box
               style={{
-                height: '200',
-                width: '100%',
-                margin: '100px auto',
-                display: 'flex',
-                justifyContent: 'space-around',
+                height: "200",
+                width: "100%",
+                margin: "100px auto",
+                display: "flex",
+                justifyContent: "space-around",
               }}
-              aria-label='Loading spinner'
+              aria-label="Loading spinner"
             >
               <CircularProgress />
             </Box>
           ) : null}
         </Dialog>
         <AssignDialog
-          id='assign-dialog'
+          id="assign-dialog"
           keepMounted
           open={assignDialogOpen}
           onClose={handleAssignDialogClose}
         />
         <NeedsVerificationDialog
-          id='needs-verification-dialog'
+          id="needs-verification-dialog"
           title='Change Listing(s) Status to "Needs Verification"'
-          message={''}
+          message={""}
           // preserveConfirmations={false}
           open={needsVerificationDialogOpen}
           onClose={handleNeedsVerificationDialogClose}
@@ -402,20 +402,20 @@ function VerificationAdmin() {
           {categoriesError || stakeholdersError || tagsError ? (
             <Box
               sx={{
-                flexGrow: '1',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                backgroundColor: '#E8E8E8',
-                textAlign: 'center',
-                padding: '4em',
+                flexGrow: "1",
+                flexDirection: "column",
+                justifyContent: "center",
+                backgroundColor: "#E8E8E8",
+                textAlign: "center",
+                padding: "4em",
               }}
             >
               <Typography
-                variant='h3'
-                component='h3'
+                variant="h3"
+                component="h3"
                 sx={{
-                  color: 'error.main',
-                  fontSize: '24pt',
+                  color: "error.main",
+                  fontSize: "24pt",
                 }}
               >
                 Uh Oh! Something went wrong!
@@ -425,27 +425,27 @@ function VerificationAdmin() {
             <Box
               style={{
                 flexGrow: 1,
-                width: '100%',
-                margin: '100px auto',
-                display: 'flex',
-                justifyContent: 'space-around',
+                width: "100%",
+                margin: "100px auto",
+                display: "flex",
+                justifyContent: "space-around",
               }}
-              aria-label='Loading spinner'
+              aria-label="Loading spinner"
             >
               <CircularProgress />
             </Box>
           ) : stakeholders && stakeholders.length === 0 ? (
             <Box
               sx={{
-                flexGrow: '1',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                backgroundColor: '#E8E8E8',
-                textAlign: 'center',
-                padding: '4em',
+                flexGrow: "1",
+                flexDirection: "column",
+                justifyContent: "center",
+                backgroundColor: "#E8E8E8",
+                textAlign: "center",
+                padding: "4em",
               }}
             >
-              <Typography variant='h5' component='h5'>
+              <Typography variant="h5" component="h5">
                 No matches found, please try different criteria
               </Typography>
             </Box>
@@ -453,31 +453,31 @@ function VerificationAdmin() {
             <>
               <Box
                 style={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  justifyContent: 'space-between',
+                  display: "flex",
+                  flexDirection: "row",
+                  justifyContent: "space-between",
                 }}
               >
-                <Stack direction='row' spacing={2} marginBottom={1}>
+                <Stack direction="row" spacing={2} marginBottom={1}>
                   <Button
-                    variant='outlined'
-                    type='button'
+                    variant="outlined"
+                    type="button"
                     disabled={selectedStakeholderIds.length === 0}
                     onClick={handleNeedsVerificationDialogOpen}
                   >
                     Needs Verification
                   </Button>
                   <Button
-                    variant='outlined'
-                    type='button'
+                    variant="outlined"
+                    type="button"
                     disabled={selectedStakeholderIds.length === 0}
                     onClick={handleAssignDialogOpen}
                   >
                     Assign
                   </Button>
                   <Button
-                    variant='outlined'
-                    type='button'
+                    variant="outlined"
+                    type="button"
                     disabled={selectedStakeholderIds.length === 0}
                     onClick={handleExport}
                   >
@@ -488,22 +488,22 @@ function VerificationAdmin() {
               </Box>
               <VerificationAdminGridMui
                 stakeholders={stakeholders}
-                mode={'admin'}
+                mode={"admin"}
                 setSelectedStakeholderIds={setSelectedStakeholderIds}
               />
             </>
           ) : (
             <Box
               sx={{
-                flexGrow: '1',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                backgroundColor: '#E8E8E8',
-                textAlign: 'center',
-                padding: '4em',
+                flexGrow: "1",
+                flexDirection: "column",
+                justifyContent: "center",
+                backgroundColor: "#E8E8E8",
+                textAlign: "center",
+                padding: "4em",
               }}
             >
-              <Typography variant='h5' component='h5'>
+              <Typography variant="h5" component="h5">
                 Please enter search criteria and execute a search
               </Typography>
             </Box>

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Button, CssBaseline, Dialog, Typography } from '@mui/material';
 import Stack from '@mui/material/Stack';
 import MuiDialogTitle from '@mui/material/DialogTitle';
-import makeStyles from '@mui/styles/makeStyles';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import { useOrganizations } from 'hooks/useOrganizations';
@@ -52,7 +51,6 @@ const DialogTitle = (props) => {
           icon='search'
           kind='close'
           onClick={onClose}
-          // className={classes.closeButton}
           sx={{
             position: 'absolute',
             right: '8px',

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -270,7 +270,7 @@ function VerificationAdmin() {
     return null;
   }
   return (
-    <Container
+    <Box
       sx={{
         flexGrow: '1',
         flexBasis: '100%',
@@ -510,7 +510,7 @@ function VerificationAdmin() {
           )}
         </>
       </Box>
-    </Container>
+    </Box>
   );
 }
 

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -79,7 +79,18 @@ const DialogTitle = (props) => {
   const classes = useStyles();
   const { children, onClose, ...other } = props;
   return (
-    <MuiDialogTitle disableTypography className={classes.root} {...other}>
+    <MuiDialogTitle
+      disableTypography
+      sx={{
+        flexGrow: '1',
+        flexBasis: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '2rem',
+        paddingBottom: '0',
+      }}
+      {...other}
+    >
       <Typography variant='h6'>{children}</Typography>
       {onClose ? (
         <Button
@@ -88,7 +99,12 @@ const DialogTitle = (props) => {
           icon='search'
           kind='close'
           onClick={onClose}
-          className={classes.closeButton}
+          // className={classes.closeButton}
+          sx={{
+            position: 'absolute',
+            right: '8px',
+            top: '8px',
+          }}
         >
           Search
         </Button>
@@ -434,11 +450,23 @@ function VerificationAdmin() {
         />
         <>
           {categoriesError || stakeholdersError || tagsError ? (
-            <Box className={classes.bigMessage}>
+            <Box
+              sx={{
+                flexGrow: '1',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                backgroundColor: '#E8E8E8',
+                textAlign: 'center',
+                padding: '4em',
+              }}
+            >
               <Typography
                 variant='h3'
                 component='h3'
-                className={classes.errorText}
+                sx={{
+                  color: 'error.main',
+                  fontSize: '24pt',
+                }}
               >
                 Uh Oh! Something went wrong!
               </Typography>
@@ -457,7 +485,16 @@ function VerificationAdmin() {
               <CircularProgress />
             </Box>
           ) : stakeholders && stakeholders.length === 0 ? (
-            <Box className={classes.bigMessage}>
+            <Box
+              sx={{
+                flexGrow: '1',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                backgroundColor: '#E8E8E8',
+                textAlign: 'center',
+                padding: '4em',
+              }}
+            >
               <Typography variant='h5' component='h5'>
                 No matches found, please try different criteria
               </Typography>
@@ -506,7 +543,16 @@ function VerificationAdmin() {
               />
             </>
           ) : (
-            <Box className={classes.bigMessage}>
+            <Box
+              sx={{
+                flexGrow: '1',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                backgroundColor: '#E8E8E8',
+                textAlign: 'center',
+                padding: '4em',
+              }}
+            >
               <Typography variant='h5' component='h5'>
                 Please enter search criteria and execute a search
               </Typography>

--- a/client/src/components/Admin/VerificationAdmin.js
+++ b/client/src/components/Admin/VerificationAdmin.js
@@ -6,6 +6,7 @@ import Stack from '@mui/material/Stack';
 import MuiDialogTitle from '@mui/material/DialogTitle';
 import makeStyles from '@mui/styles/makeStyles';
 import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
 import { useOrganizations } from 'hooks/useOrganizations';
 import { useCategories } from 'hooks/useCategories';
 import { useNeighborhoods } from 'hooks/useNeighborhoods';
@@ -24,24 +25,25 @@ import { useUserContext } from '../../contexts/userContext';
 import { useSearchCoordinates, useUserCoordinates } from '../../appReducer';
 import CircularProgress from '@mui/material/CircularProgress';
 import VerificationAdminGridMui from './VerificationAdminGridMui';
+import { AddBoxOutlined, GifBox, GifBoxTwoTone } from '@mui/icons-material';
 
 const CRITERIA_TOKEN = 'verificationAdminCriteria';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-    flexBasis: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    padding: '2rem',
-    paddingBottom: '0',
-  },
-  mainContent: {
-    flexGrow: 1,
-    padding: theme.spacing(2),
-    display: 'flex',
-    flexDirection: 'column',
-  },
+  // root: {
+  //   flexGrow: 1,
+  //   flexBasis: '100%',
+  //   display: 'flex',
+  //   flexDirection: 'column',
+  //   padding: '2rem',
+  //   paddingBottom: '0',
+  // },
+  // mainContent: {
+  //   flexGrow: 1,
+  //   padding: theme.spacing(2),
+  //   display: 'flex',
+  //   flexDirection: 'column',
+  // },
   closeButton: {
     position: 'absolute',
     right: theme.spacing(1),
@@ -302,10 +304,19 @@ function VerificationAdmin() {
     return null;
   }
   return (
-    <main className={classes.root}>
+    <Container
+      sx={{
+        flexGrow: '1',
+        flexBasis: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '2rem',
+        paddingBottom: '0',
+      }}
+    >
       <CssBaseline />
-      <div
-        style={{
+      <Box
+        sx={{
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
@@ -336,7 +347,7 @@ function VerificationAdmin() {
             Criteria...
           </Button>
         </Box>
-      </div>
+      </Box>
       <SearchCriteriaDisplay
         defaultCriteria={defaultCriteria}
         criteria={criteria}
@@ -347,7 +358,14 @@ function VerificationAdmin() {
         tags={tags}
         isLoading={neighborhoodsLoading || categoriesLoading}
       />
-      <div className={classes.mainContent}>
+      <Box
+        sx={{
+          flexGrow: '1',
+          padding: '2',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
         <Dialog
           open={dialogOpen}
           onClose={handleDialogClose}
@@ -356,7 +374,7 @@ function VerificationAdmin() {
         >
           <DialogTitle onClose={handleDialogClose}>Search Criteria</DialogTitle>
           {criteria ? (
-            <div style={{ overflowY: 'scroll' }}>
+            <Box sx={{ overflowY: 'scroll' }}>
               <SearchCriteria
                 key={JSON.stringify({
                   userLatitude:
@@ -375,18 +393,18 @@ function VerificationAdmin() {
                 criteria={criteria}
                 setCriteria={setCriteria}
               />
-            </div>
+            </Box>
           ) : null}
           {categoriesError ||
           neighborhoodsError ||
           stakeholdersError ||
           tagsError ? (
-            <div> Uh Oh! Something went wrong!</div>
+            <Typography> Uh Oh! Something went wrong!</Typography>
           ) : categoriesLoading ||
             neighborhoodsLoading ||
             stakeholdersLoading ||
             tagsLoading ? (
-            <div
+            <Box
               style={{
                 height: '200',
                 width: '100%',
@@ -397,7 +415,7 @@ function VerificationAdmin() {
               aria-label='Loading spinner'
             >
               <CircularProgress />
-            </div>
+            </Box>
           ) : null}
         </Dialog>
         <AssignDialog
@@ -416,7 +434,7 @@ function VerificationAdmin() {
         />
         <>
           {categoriesError || stakeholdersError || tagsError ? (
-            <div className={classes.bigMessage}>
+            <Box className={classes.bigMessage}>
               <Typography
                 variant='h3'
                 component='h3'
@@ -424,9 +442,9 @@ function VerificationAdmin() {
               >
                 Uh Oh! Something went wrong!
               </Typography>
-            </div>
+            </Box>
           ) : categoriesLoading || stakeholdersLoading | tagsLoading ? (
-            <div
+            <Box
               style={{
                 flexGrow: 1,
                 width: '100%',
@@ -437,16 +455,16 @@ function VerificationAdmin() {
               aria-label='Loading spinner'
             >
               <CircularProgress />
-            </div>
+            </Box>
           ) : stakeholders && stakeholders.length === 0 ? (
-            <div className={classes.bigMessage}>
+            <Box className={classes.bigMessage}>
               <Typography variant='h5' component='h5'>
                 No matches found, please try different criteria
               </Typography>
-            </div>
+            </Box>
           ) : stakeholders ? (
             <>
-              <div
+              <Box
                 style={{
                   display: 'flex',
                   flexDirection: 'row',
@@ -479,8 +497,8 @@ function VerificationAdmin() {
                     Export
                   </Button>
                 </Stack>
-                <div>{`${stakeholders.length} rows`} </div>
-              </div>
+                <Box>{`${stakeholders.length} rows`} </Box>
+              </Box>
               <VerificationAdminGridMui
                 stakeholders={stakeholders}
                 mode={'admin'}
@@ -488,15 +506,15 @@ function VerificationAdmin() {
               />
             </>
           ) : (
-            <div className={classes.bigMessage}>
+            <Box className={classes.bigMessage}>
               <Typography variant='h5' component='h5'>
                 Please enter search criteria and execute a search
               </Typography>
-            </div>
+            </Box>
           )}
         </>
-      </div>
-    </main>
+      </Box>
+    </Container>
   );
 }
 


### PR DESCRIPTION
Fixes #1833 

**Changes made:**
- Replaced HTML with Material UI Components in `VerificationAdmin.js`
- Removed `makeStyles` calls
- Replaced `className` attributes with `sx` prop


**Why changes were made:**
- Our current use of `makeStyles` relies on JSS, a styling system that is now deprecated in Material UI v5. Material UI documentation recommends styling with the `sx` prop instead to make use of Material UI v5's new styling engine, Emotion.


**Screenshots of proposed changes**
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/hackforla/food-oasis/assets/111248453/1ac79e01-49b7-499d-b05b-21e2acf50a10

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
https://github.com/hackforla/food-oasis/assets/111248453/c1c63da2-1ede-48b8-9902-ca1a0cc55d48

</details>