### PR TITLE
Update styling to use sx prop TagAdmin.js 1832

### DIFF
--- a/client/src/components/Admin/TagAdmin.js
+++ b/client/src/components/Admin/TagAdmin.js
@@ -145,7 +145,7 @@ function TagAdmin(props) {
           justifyContent: "space-between",
         }}
       >
-        <Typography variant="h2" style={{ margin: 0 }}>
+        <Typography variant="h2" style={{ margin: 0, fontWeight: "bold" }}>
           Tags
         </Typography>
         <Button variant="outlined" onClick={handleAddNew}>
@@ -271,7 +271,13 @@ function TagAdmin(props) {
               padding: (2, 4, 3),
             }}
           >
-            <Typography variant="h2" id="simple-modal-title">
+            <Typography
+              variant="h2"
+              id="simple-modal-title"
+              sx={{
+                fontWeight: "bold",
+              }}
+            >
               Edit Tag
             </Typography>
 

--- a/client/src/components/Admin/TagAdmin.js
+++ b/client/src/components/Admin/TagAdmin.js
@@ -15,11 +15,12 @@ import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
 import { IconButton } from "../UI/StandardButton";
 import { Formik } from "formik";
 import { tenantId } from "helpers/Configuration";
 // import IconButton from "components/UI/IconButton";
-import { Navigate,useLocation  } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import Label from "./ui/Label";
 
 const columns = [
@@ -86,9 +87,7 @@ function TagAdmin(props) {
   React.useEffect(() => {
     if (status === 401) {
       return (
-        <Navigate
-          to={{ pathname: "/login", state: { from: location } }}
-        />
+        <Navigate to={{ pathname: "/login", state: { from: location } }} />
       );
     }
   });
@@ -138,15 +137,17 @@ function TagAdmin(props) {
 
   return (
     <Container maxWidth="sm">
-      <div className={classes.heading}>
-        <h2 style={{ margin: 0 }}>Tags</h2>
+      <Box className={classes.heading}>
+        <Typography variant="h2" style={{ margin: 0 }}>
+          Tags
+        </Typography>
         <Button variant="outlined" onClick={handleAddNew}>
           Add New
         </Button>
-      </div>
+      </Box>
 
       {deleteError && (
-        <div className={classes.error}>Something went wrong.</div>
+        <Typography className={classes.error}>Something went wrong.</Typography>
       )}
 
       <Paper>
@@ -242,10 +243,10 @@ function TagAdmin(props) {
           aria-labelledby="tag-modal"
           aria-describedby="tag-modal-description"
         >
-          <div style={modalStyle} className={classes.paper}>
-            <div id="simple-modal-title">
-              <h2>Edit Tag</h2>
-            </div>
+          <Box style={modalStyle} className={classes.paper}>
+            <Typography variant="h2" id="simple-modal-title">
+              Edit Tag
+            </Typography>
 
             <Formik
               initialValues={{
@@ -267,7 +268,7 @@ function TagAdmin(props) {
                     handleSubmit(e);
                   }}
                 >
-                  <div>
+                  <Box>
                     <Label id="name" label="Name" />
                     <TextField
                       placeholder="Name"
@@ -279,10 +280,12 @@ function TagAdmin(props) {
                       fullWidth
                       autoFocus
                     />
-                  </div>
+                  </Box>
 
                   {error && (
-                    <div className={classes.error}>Something went wrong.</div>
+                    <Typography className={classes.error}>
+                      Something went wrong.
+                    </Typography>
                   )}
                   <Box mt={3} display="flex" justifyContent="space-between">
                     <Button
@@ -302,7 +305,7 @@ function TagAdmin(props) {
                 </form>
               )}
             </Formik>
-          </div>
+          </Box>
         </Modal>
       </Paper>
     </Container>

--- a/client/src/components/Admin/TagAdmin.js
+++ b/client/src/components/Admin/TagAdmin.js
@@ -16,6 +16,7 @@ import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
+import { spacing } from "@mui/system";
 import { IconButton } from "../UI/StandardButton";
 import { Formik } from "formik";
 import { tenantId } from "helpers/Configuration";
@@ -137,7 +138,13 @@ function TagAdmin(props) {
 
   return (
     <Container maxWidth="sm">
-      <Box className={classes.heading}>
+      <Box
+        sx={{
+          marginBottom: 1,
+          display: "flex",
+          justifyContent: "space-between",
+        }}
+      >
         <Typography variant="h2" style={{ margin: 0 }}>
           Tags
         </Typography>
@@ -147,11 +154,22 @@ function TagAdmin(props) {
       </Box>
 
       {deleteError && (
-        <Typography className={classes.error}>Something went wrong.</Typography>
+        <Typography
+          sx={{
+            color: "error.main",
+          }}
+        >
+          Something went wrong.
+        </Typography>
       )}
 
       <Paper>
-        <TableContainer className={classes.container}>
+        <TableContainer
+          sx={{
+            maxHeight: "500px",
+            cursor: "pointer",
+          }}
+        >
           <Table stickyHeader aria-label="sticky table">
             <TableHead>
               <TableRow>
@@ -243,7 +261,16 @@ function TagAdmin(props) {
           aria-labelledby="tag-modal"
           aria-describedby="tag-modal-description"
         >
-          <Box style={modalStyle} className={classes.paper}>
+          <Box
+            style={modalStyle}
+            sx={{
+              position: "absolute",
+              width: 400,
+              backgroundColor: "background.paper",
+              boxShadow: 5,
+              padding: (2, 4, 3),
+            }}
+          >
             <Typography variant="h2" id="simple-modal-title">
               Edit Tag
             </Typography>
@@ -283,7 +310,11 @@ function TagAdmin(props) {
                   </Box>
 
                   {error && (
-                    <Typography className={classes.error}>
+                    <Typography
+                      sx={{
+                        color: "error.main",
+                      }}
+                    >
                       Something went wrong.
                     </Typography>
                   )}


### PR DESCRIPTION
Fixes #1832  

**Changes made:**
- Replaced HTML with Material UI Components in `TagAdmin.js`
- Removed `makeStyles` calls
- Replaced `className` attributes with `sx` prop


**Why changes were made:**
- Our current use of `makeStyles` relies on JSS, a styling system that is now deprecated in Material UI v5. Material UI documentation recommends styling with the `sx` prop instead to make use of Material UI v5's new styling engine, Emotion.


**Screenshots of proposed changes**
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
_Note: In the screen recordings, modals appear to pop up in different parts of the screen in before vs after because the original code includes a `getModalStyle()` function that adds/subtracts a random amount from the top and left position values. This results in the modal popping up on different parts of the screen in each render._

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/hackforla/food-oasis/assets/111248453/02809384-bc97-4309-a37f-752600dda2f2

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
https://github.com/hackforla/food-oasis/assets/111248453/f95ea74d-8884-45c2-9689-1f302f368023

</details>