### PR TITLE
1861-Align Map Search Textinput and Icon

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/ResultsFilters.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/ResultsFilters.js
@@ -137,7 +137,11 @@ const ResultsFilters = ({
             </Grid2>
           </Grid2>
           <Grid2 xs={12} sm={6}>
-            <Stack direction="row" sx={{ margin: "0.5rem" }}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              sx={{ margin: "0.5rem" }}
+            >
               <AddressDropDown />
               <Tooltip
                 title={


### PR DESCRIPTION
Before: textinput and search icon are not aligned 
![before](https://github.com/hackforla/food-oasis/assets/60997220/1c562310-08e0-497f-9619-b53694e86c64)

After:
![after](https://github.com/hackforla/food-oasis/assets/60997220/2b6b09c5-1890-42e8-ae24-750a147a9a0d)

closes #1861 