### PR TITLE
Updated styling for Importfileguide.js

### DIFF
--- a/client/src/components/Admin/ImportOrganizations/ImportFileGuide.js
+++ b/client/src/components/Admin/ImportOrganizations/ImportFileGuide.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import {
+  Box,
   Button,
   Input,
   FormControl,
@@ -15,52 +16,12 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
 import { STAKEHOLDER_SCHEMA } from "../../../constants/stakeholder-schema";
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    textAlign: "center",
-  },
-  section: {
-    marginTop: theme.spacing(2),
-    maxWidth: "800px",
-    margin: "0 auto",
-    padding: theme.spacing(4),
-    borderRadius: "8px",
-    boxShadow: "-.2rem 0 2rem #C7CCD1",
-    "& strong": {
-      color: theme.palette.error.main,
-    },
-    "& button": {
-      marginTop: theme.spacing(2),
-      minWidth: "200px",
-    },
-  },
-  tableCell: {},
-  tableRow: {
-    "&:nth-of-type(odd)": {
-      backgroundColor: theme.palette.action.hover,
-    },
-  },
-  instructions: {
-    margin: "0 auto",
-    maxWidth: "650px",
-    textAlign: "left",
-  },
-  formControl: {
-    display: "block",
-    marginLeft: "auto",
-    paddingRight: "0",
-    width: "100px",
-  },
-}));
 
 const ImportFileGuide = (props) => {
   const { handleDownload, handleChange, handleUpload, file } = props;
   const [visibleFields, setVisibleFields] = useState("all");
   const ref = useRef(null);
-  const classes = useStyles(props);
 
   const handleVisibleFields = (e) => {
     const { value } = e.target;
@@ -72,113 +33,188 @@ const ImportFileGuide = (props) => {
   }, [file]);
 
   return (
-    <main className={classes.root}>
-      <div>
-        <section className={classes.section}>
-          <Typography variant="h5">CSV Import</Typography>
-          <Typography>
-            <strong>Warning: this feature is still being tested. </strong>
-          </Typography>
-          <ul className={classes.instructions}>
-            <li>
-              You will have a chance to review your data before importing.
-            </li>
-            <li>
-              Refer to the formatting guides below. Do not change any column
-              names.
-            </li>
-          </ul>
-          <br />
-          <Input type="file" onChange={handleChange} inputRef={ref} />
-          <br />
-          <Button variant="contained" type="button" onClick={handleUpload}>
-            Submit
-          </Button>
-        </section>
-        <section className={classes.section}>
-          <Typography variant="h5">CSV Template</Typography>
-          <ul className={classes.instructions}>
-            <li>
-              Download a CSV template to ensure proper formatting and column
-              names.
-            </li>
-            <li>Do not change column names or order.</li>
-          </ul>
-          <Button variant="contained" type="button" onClick={handleDownload}>
-            Download CSV template
-          </Button>
-        </section>
-        <section className={classes.section}>
-          <Typography variant="h5">Schema Guide</Typography>
-          <Typography>
-            The schema below lists the CSV column names, meanings, and
-            guidelines.
-          </Typography>
-          <FormControl className={classes.formControl}>
-            <Select
-              defaultValue="all"
-              onChange={handleVisibleFields}
-              style={{ width: "100%" }}
-            >
-              <MenuItem value="all">All</MenuItem>
-              <MenuItem value="required">Required</MenuItem>
-            </Select>
-            <FormHelperText>Show columns</FormHelperText>
-          </FormControl>
-          <TableContainer>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Column name</TableCell>
-                  <TableCell>Description</TableCell>
-                  <TableCell>Default value</TableCell>
-                  <TableCell>Sample format</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {STAKEHOLDER_SCHEMA.map(
-                  (field) =>
-                    field.show &&
-                    (visibleFields === "all" ? (
-                      <TableRow key={field.name} className={classes.tableRow}>
-                        <TableCell
-                          style={{ fontWeight: field.required && 900 }}
-                        >
+    <main 
+      style={{
+        textAlign: "center",
+      }}
+    >
+      <Box 
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+          maxWidth: "800px",
+          mx: 'auto',
+          padding: theme.spacing(4),
+          borderRadius: "8px",
+          boxShadow: "-.2rem 0 2rem #C7CCD1",
+          "& strong": {
+            color: theme.palette.error.main,
+          },
+          "& button": {
+            marginTop: theme.spacing(2),
+            minWidth: "200px",
+          },
+        })}
+      >
+        <Typography variant="h5">CSV Import</Typography>
+        <Typography>
+          <strong>Warning: this feature is still being tested. </strong>
+        </Typography>
+        <Box component="ul" 
+          sx={{
+            margin: "0 auto",
+            maxWidth: "650px",
+            textAlign: "left"
+          }}
+        >
+          <Box component="li">You will have a chance to review your data before importing.</Box>
+          <Box component="li">Refer to the formatting guides below. Do not change any column
+            names.</Box>
+        </Box>
+        <br />
+        <Input type="file" onChange={handleChange} inputRef={ref} />
+        <br />
+        <Button variant="contained" type="button" onClick={handleUpload}>
+          Submit
+        </Button>
+      </Box>
+      <Box 
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+          maxWidth: "800px",
+          mx: 'auto',
+          padding: theme.spacing(4),
+          borderRadius: "8px",
+          boxShadow: "-.2rem 0 2rem #C7CCD1",
+          "& strong": {
+            color: theme.palette.error.main,
+          },
+          "& button": {
+            marginTop: theme.spacing(2),
+            minWidth: "200px",
+          },
+        })}
+      >
+        <Typography variant="h5">CSV Template</Typography>
+        <Box component="ul" 
+          sx={{
+            margin: "0 auto",
+            maxWidth: "650px",
+            textAlign: "left"
+          }}
+        >
+          <Box component="li">Download a CSV template to ensure proper formatting and column
+            names.</Box>
+          <Box component="li">Do not change column names or order.</Box>
+        </Box>
+        <Button variant="contained" type="button" onClick={handleDownload}>
+          Download CSV template
+        </Button>
+      </Box>
+      <Box 
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+          maxWidth: "800px",
+          mx: 'auto',
+          padding: theme.spacing(4),
+          borderRadius: "8px",
+          boxShadow: "-.2rem 0 2rem #C7CCD1",
+          "& strong": {
+            color: theme.palette.error.main,
+          },
+          "& button": {
+            marginTop: theme.spacing(2),
+            minWidth: "200px",
+          },
+        })}
+      >
+        <Typography variant="h5">Schema Guide</Typography>
+        <Typography>
+          The schema below lists the CSV column names, meanings, and
+          guidelines.
+        </Typography>
+        <FormControl 
+          sx={{
+            display: "block",
+            marginLeft: "auto",
+            paddingRight: "0",
+            width: "100px",
+          }}
+        >
+          <Select
+            defaultValue="all"
+            onChange={handleVisibleFields}
+            style={{ width: "100%" }}
+          >
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="required">Required</MenuItem>
+          </Select>
+          <FormHelperText>Show columns</FormHelperText>
+        </FormControl>
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Column name</TableCell>
+                <TableCell>Description</TableCell>
+                <TableCell>Default value</TableCell>
+                <TableCell>Sample format</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {STAKEHOLDER_SCHEMA.map(
+                (field) =>
+                  field.show &&
+                  (visibleFields === "all" ? (
+                    <TableRow key={field.name} 
+                      sx={(theme) => ({
+                        "&:nth-of-type(odd)": {
+                          backgroundColor: theme.palette.action.hover,
+                        }
+                      })}
+                    >
+                      <TableCell
+                        style={{ fontWeight: field.required && 900 }}
+                      >
+                        {`${field.name} ${
+                          field.required ? "(required)" : ""
+                        }`}
+                      </TableCell>
+                      <TableCell>{field.description}</TableCell>
+                      <TableCell
+                        style={{ fontWeight: field.required && 900 }}
+                      >
+                        {field.default_value}
+                      </TableCell>
+                      <TableCell>{field.sample_format}</TableCell>
+                    </TableRow>
+                  ) : (
+                    visibleFields === "required" &&
+                    field.required && (
+                      <TableRow key={field.name} 
+                        sx={(theme) => ({
+                          "&:nth-of-type(odd)": {
+                            backgroundColor: theme.palette.action.hover,
+                          }
+                        })}
+                      >
+                        <TableCell style={{ fontWeight: 900 }}>
                           {`${field.name} ${
                             field.required ? "(required)" : ""
                           }`}
                         </TableCell>
                         <TableCell>{field.description}</TableCell>
-                        <TableCell
-                          style={{ fontWeight: field.required && 900 }}
-                        >
+                        <TableCell style={{ fontWeight: 900 }}>
                           {field.default_value}
                         </TableCell>
                         <TableCell>{field.sample_format}</TableCell>
                       </TableRow>
-                    ) : (
-                      visibleFields === "required" &&
-                      field.required && (
-                        <TableRow key={field.name} className={classes.tableRow}>
-                          <TableCell style={{ fontWeight: 900 }}>
-                            {`${field.name} ${
-                              field.required ? "(required)" : ""
-                            }`}
-                          </TableCell>
-                          <TableCell>{field.description}</TableCell>
-                          <TableCell style={{ fontWeight: 900 }}>
-                            {field.default_value}
-                          </TableCell>
-                          <TableCell>{field.sample_format}</TableCell>
-                        </TableRow>
-                      )
-                    ))
-                )}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </section>
-      </div>
+                    )
+                  ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
     </main>
   );
 };


### PR DESCRIPTION
- Closes #1836 
- Updated margin property to mx since it was overriding marginTop property.
- Borrowed styling approach of the main tag from Belen's PR 1843. Thanks @93Belen 
- Also, I had to install a few dependencies and I have not included the updated package-lock.json with this PR. Will check with team if it should be included in a separate PR.
- No changes in before and after, screenshots below.
<details><summary>Before</summary>
<img src="https://github.com/hackforla/food-oasis/assets/843538/68824700-312e-442c-9e3a-0f849deb6958.jpeg" width="90%" height="60%">

</details>
<details><summary>After</summary>
<img src="https://github.com/hackforla/food-oasis/assets/843538/66dd9daa-c369-4646-ac13-a8aeb3bc4d21.jpeg" width="90%" height="60%">

</details>
