### PR TITLE
fixed textfield border bug in addressdropdown js file v1

### DIFF
--- a/client/src/components/FoodSeeker/AddressDropDown.js
+++ b/client/src/components/FoodSeeker/AddressDropDown.js
@@ -52,7 +52,10 @@ export default function AddressDropDown({ showSearchIcon }) {
   const renderInput = (params) => {
     return (
       <TextField
-        variant="outlined"
+        sx={{
+          background: "#FFFFFF",
+        }}
+		variant="outlined"
         {...params}
         label="Search by address or zip code"
         margin="none"
@@ -71,6 +74,7 @@ export default function AddressDropDown({ showSearchIcon }) {
         InputProps={{
           sx: {
             cursor: "pointer",
+			backgroundColor: "#F0F0F0"
           },
           endAdornment: (
             <InputAdornment


### PR DESCRIPTION
- Closes #1899 
- Please see the screenshots below to notice the bug fix (around the corners of "Search by address or zip code" textfield).
- Before
![TextField before](https://github.com/hackforla/food-oasis/assets/843538/ab9b6857-f572-4748-aff4-0a2953427bfe)
- After
![TextField after](https://github.com/hackforla/food-oasis/assets/843538/59ab19ca-dd24-4534-8dcf-c04be6309c33)
