### PR TITLE
Update Styling System to Use sx Prop in Material-UI for ResultsMap.js （ticket #1856 ）

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.js
@@ -156,12 +156,18 @@ const ResultsMap = (
       mapStyle={MAPBOX_STYLE}
       {...viewport}
       onViewportChange={setViewport}
-      onLoad={onLoad}
+      onLoad={(event)=> { 
+        event.target.removeControl(event.target.attributionControl);
+        if (typeof onLoad === 'function'){
+          onLoad(event);
+        }
+      }}
       onClick={onClick}
       interactiveLayerIds={interactiveLayerIds}
       getCursor={getCursor}
       width="100%"
       height="100%"
+      style={{ position: "relative"}}
     >
       {startIconCoordinates && (
         <Map.Marker
@@ -176,6 +182,7 @@ const ResultsMap = (
       )}
       <Map.NavigationControl
         showCompass={false}
+        style={{ top: 8, right: 8}}
       />
       {markersLoaded && (
         <Map.Source type="geojson" data={markersGeojson}>

--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.js
@@ -156,18 +156,13 @@ const ResultsMap = (
       mapStyle={MAPBOX_STYLE}
       {...viewport}
       onViewportChange={setViewport}
-      onLoad={(event)=> { 
-        event.target.removeControl(event.target.attributionControl);
-        if (typeof onLoad === 'function'){
-          onLoad(event);
-        }
-      }}
+      onLoad={onLoad}
       onClick={onClick}
       interactiveLayerIds={interactiveLayerIds}
       getCursor={getCursor}
       width="100%"
       height="100%"
-      style={{ position: "relative"}}
+      style={{ position: "relative" }}
     >
       {startIconCoordinates && (
         <Map.Marker
@@ -180,10 +175,7 @@ const ResultsMap = (
           <StartIcon />
         </Map.Marker>
       )}
-      <Map.NavigationControl
-        showCompass={false}
-        style={{ top: 8, right: 8}}
-      />
+      <Map.NavigationControl showCompass={false} style={{ top: 8, right: 8 }} />
       {markersLoaded && (
         <Map.Source type="geojson" data={markersGeojson}>
           <Map.Layer {...markersLayerStyles} />
@@ -195,7 +187,6 @@ const ResultsMap = (
           <Map.Layer {...regionBorderStyle} />
         </Map.Source>
       )}
-
     </ReactMapGL>
   );
 };

--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.js
@@ -24,7 +24,6 @@ import {
   useMarkersGeojson,
 } from "./MarkerHelpers";
 import { regionFillStyle, regionBorderStyle } from "./RegionHelpers";
-import useStyles from "./styles";
 import * as analytics from "services/analytics";
 import {
   useSearchCoordinates,
@@ -46,7 +45,6 @@ const ResultsMap = (
   },
   ref
 ) => {
-  const classes = useStyles();
   const mapRef = useRef();
   const [markersLoaded, setMarkersLoaded] = useState(false);
   const searchCoordinates = useSearchCoordinates();
@@ -164,7 +162,6 @@ const ResultsMap = (
       getCursor={getCursor}
       width="100%"
       height="100%"
-      className={classes.map}
     >
       {startIconCoordinates && (
         <Map.Marker
@@ -179,7 +176,6 @@ const ResultsMap = (
       )}
       <Map.NavigationControl
         showCompass={false}
-        className={classes.navigationControl}
       />
       {markersLoaded && (
         <Map.Source type="geojson" data={markersGeojson}>


### PR DESCRIPTION
Closes #1856 
Related to ticket #1848 

Update 
1. This update applies necessary styling changes directly within the ResultsMap.js component. The modifications involve removing the dependency on the useStyle import from Style.js. 
2. In preparation for the pull request, executed a rebase operation to align my feature branch with the latest updates from the development branch. 
3. The visual documentation has been updated with before and after images.

Summary 
In this ticket, the original makeStyle styles from styles.js have been directly integrated into ResultsMap.js. ReactMapGL is incompatible with the 'xs' property provided by Material-UI. As a workaround, we've implemented styling through the 'style' attribute.

Screenshot 
Before image
![replaced_before](https://github.com/hackforla/food-oasis/assets/101593133/a50bca48-286e-4127-a88e-11edb8d461dd)

Afterimage 
![replaced_after](https://github.com/hackforla/food-oasis/assets/101593133/d4d7f3b2-ad0f-438e-9729-6a35f5215d22)
