### PR TITLE
removes redundancy for preview component in mobile view

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/SearchResults.js
+++ b/client/src/components/FoodSeeker/SearchResults/SearchResults.js
@@ -8,14 +8,11 @@ import * as analytics from "services/analytics";
 import {
   useAppDispatch,
   useSearchCoordinates,
-  useSelectedOrganization,
   useStakeholders,
 } from "../../../appReducer";
 import Filters from "./ResultsFilters/ResultsFilters";
 import List from "./ResultsList/ResultsList";
 import Map from "./ResultsMap/ResultsMap";
-import Details from "./StakeholderDetails/StakeholderDetails";
-import Preview from "./StakeholderPreview/StakeholderPreview";
 import { Desktop, Mobile, Tablet } from "./layouts";
 
 const SearchResults = () => {
@@ -27,7 +24,6 @@ const SearchResults = () => {
   const [showList, setShowList] = useState(true);
   const searchCoordinates = useSearchCoordinates();
   const dispatch = useAppDispatch();
-  const selectedOrganization = useSelectedOrganization();
   const location = useLocation();
   const neighborhoodId = new URLSearchParams(location.search).get(
     "neighborhood_id"
@@ -140,18 +136,7 @@ const SearchResults = () => {
 
   if (isTablet) return <Tablet filters={filters} map={map} list={list} />;
 
-  return (
-    <Mobile
-      showList={showList}
-      filters={filters}
-      map={map}
-      list={list}
-      preview={
-        selectedOrganization && <Preview stakeholder={selectedOrganization} />
-      }
-      details={selectedOrganization && <Details />}
-    />
-  );
+  return <Mobile showList={showList} filters={filters} map={map} list={list} />;
 };
 
 export default SearchResults;

--- a/client/src/components/FoodSeeker/SearchResults/layouts/Mobile.js
+++ b/client/src/components/FoodSeeker/SearchResults/layouts/Mobile.js
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Draggable from "react-draggable";
 import { useFilterPanel } from "appReducer";
 
@@ -12,8 +12,7 @@ const overlay = {
   borderRadius: "10px",
 };
 
-const MobileLayout = ({ filters, map, list, preview, details, showList }) => {
-  const [showDetails, setShowDetails] = useState(false);
+const MobileLayout = ({ filters, map, list, showList }) => {
   const [position, setPosition] = useState();
   const filterPanelOpen = useFilterPanel();
 
@@ -30,32 +29,22 @@ const MobileLayout = ({ filters, map, list, preview, details, showList }) => {
       });
     }
   }, [showList]);
-
   useEffect(() => {
-    if (!details) setShowDetails(false);
-  }, [details]);
-
-  useEffect(() => {
-    if(filterPanelOpen){
+    if (filterPanelOpen) {
       setPosition({
         x: 0,
-        y: window.innerHeight
+        y: window.innerHeight,
       });
-    }
-    else {
+    } else {
       setPosition({
         x: 0,
         y: 60,
       });
     }
-  }, [filterPanelOpen])
-
-  const show = useCallback(() => setShowDetails(true), []);
+  }, [filterPanelOpen]);
 
   // Define the bounds for vertical dragging
   const minY = 50;
-  //const maxY = 800;
-  //commented out const maxY above since it is currently not being used but might be useful in future
 
   return (
     <>
@@ -106,12 +95,6 @@ const MobileLayout = ({ filters, map, list, preview, details, showList }) => {
             </Box>
           </Draggable>
         )}
-        {preview && (
-          <Box sx={{ margin: "0 1em", flex: 0 }} onClick={show}>
-            {preview}
-          </Box>
-        )}
-        {details && showDetails && <Box sx={overlay}>{details}</Box>}
       </Box>
     </>
   );


### PR DESCRIPTION
`StakeholderPreview` component currently is in both `ResultList` component and Mobile Layout.  while `ResultList` component is also in Mobile layout .

The app behaves the same when removing the preview component from the Mobile Layout. 



https://github.com/hackforla/food-oasis/assets/68657634/a8f79674-8260-41f8-90b8-7b4556ec09a7

