### PR TITLE
proposes two options for `SwitchViewsButton` component

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
@@ -25,34 +25,16 @@ const SwitchButton = styled(Button)(({ theme }) => ({
 export default function SwitchViewsButton({ isListView, onClick }) {
   return (
     <SwitchButton onClick={onClick}>
-      {!isListView && (
-        <>
-          <Typography
-            sx={{
-              fontSize: "16px",
-              textTransform: "capitalize",
-              fontWeight: "500",
-            }}
-            color="inherit"
-          >
-            List
-          </Typography>
-        </>
-      )}
-      {isListView && (
-        <>
-          <Typography
-            sx={{
-              fontSize: "16px",
-              textTransform: "capitalize",
-              fontWeight: "500",
-            }}
-            color="inherit"
-          >
-            Map
-          </Typography>
-        </>
-      )}
+      <Typography
+        sx={{
+          fontSize: "16px",
+          textTransform: "capitalize",
+          fontWeight: "500",
+        }}
+        color="inherit"
+      >
+        {isListView ? "Map" : "List"}
+      </Typography>
     </SwitchButton>
   );
 }

--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
@@ -3,13 +3,13 @@ import { Button, Typography, styled } from "@mui/material";
 // Override standard button hover behavior
 const SwitchButton = styled(Button)(({ theme }) => ({
   background: 'white',
-      color: 'black',
-      border: '#D5D5D6 solid 1px',
-      borderRadius: '10px',
-      boxShadow: 'none',
-      width: '48px',
-      height: '40px',
-      minWidth: '0px',
+  color: 'black',
+  border: '#D5D5D6 solid 1px',
+  borderRadius: '10px',
+  boxShadow: 'none',
+  width: '48px',
+  height: '40px',
+  minWidth: '0px',
   "&:hover": {
     color: "inherit",
     backgroundColor: "white",
@@ -17,35 +17,147 @@ const SwitchButton = styled(Button)(({ theme }) => ({
   },
 }));
 
+
 export default function SwitchViewsButton({ isListView, onClick }) {
   return (
-    <SwitchButton
-    sx={{
-      maxWidth: '48px'
-    }}
-     onClick={onClick}>
+    <SwitchButton onClick={onClick}>
       {!isListView && (
         <>
           <Typography
-          sx={{
-            fontSize: '16px',
-            textTransform: 'capitalize',
-            fontWeight: '500'
-          }}
-          color="inherit">List</Typography>
+            sx={{
+              fontSize: "16px",
+              textTransform: "capitalize",
+              fontWeight: "500",
+            }}
+            color="inherit"
+          >
+            List
+          </Typography>
         </>
       )}
       {isListView && (
         <>
           <Typography
-          sx={{
-            fontSize: '16px',
-            textTransform: 'capitalize',
-            fontWeight: '500'
-          }}
-           color="inherit">Map</Typography>
+            sx={{
+              fontSize: "16px",
+              textTransform: "capitalize",
+              fontWeight: "500",
+            }}
+            color="inherit"
+          >
+            Map
+          </Typography>
         </>
       )}
     </SwitchButton>
   );
 }
+
+// Proposed Option 1: we use the existing button palette, we can removes styled dependency to simplify the component
+// import { Button, Typography } from "@mui/material";
+
+// export default function SwitchViewsButton({ isListView, onClick }) {
+//   return (
+//     <Button
+//       sx={{
+//         border: "#D5D5D6 solid 1px",
+//         borderRadius: "10px",
+//         boxShadow: "none",
+//         width: "48px",
+//         height: "40px",
+//         minWidth: "0px",
+//       }}
+//       onClick={onClick}
+//     >
+//       {!isListView && (
+//         <>
+//           <Typography
+//             sx={{
+//               fontSize: "16px",
+//               textTransform: "capitalize",
+//               fontWeight: "500",
+//             }}
+//             color="inherit"
+//           >
+//             List
+//           </Typography>
+//         </>
+//       )}
+//       {isListView && (
+//         <>
+//           <Typography
+//             sx={{
+//               fontSize: "16px",
+//               textTransform: "capitalize",
+//               fontWeight: "500",
+//             }}
+//             color="inherit"
+//           >
+//             Map
+//           </Typography>
+//         </>
+//       )}
+//     </Button>
+//   );
+// }
+
+// Proposed Option 2: we modify the hover, active, focus state of this toggle button
+// Override standard button to keep the background color as white for hover, active, focus states
+// import { Button, Typography, styled } from "@mui/material";
+
+// const SwitchButton = styled(Button)(({ theme }) => ({
+//   color: theme.palette.common.black,
+//   backgroundColor: theme.palette.common.white,
+//   border: "#D5D5D6 solid 1px",
+//   borderRadius: "10px",
+//   boxShadow: "none",
+//   width: "48px",
+//   height: "40px",
+//   minWidth: "0px",
+//   "&:hover": {
+//     backgroundColor: theme.palette.common.white,
+//   },
+//   "&:active": {
+//     backgroundColor: theme.palette.common.white,
+//     boxShadow: "inset 0px 8px 4px rgba(0,0,0,0.24)",
+//   },
+//   "&:focus": {
+//     backgroundColor: theme.palette.common.white,
+//     filter: "drop-shadow(0px 0px 12px rgba(255, 255, 255, 0.8))",
+//   },
+// }));
+
+// export default function SwitchViewsButton({ isListView, onClick }) {
+//   return (
+//     <SwitchButton onClick={onClick}>
+//       {!isListView && (
+//         <>
+//           <Typography
+//             sx={{
+//               fontSize: "16px",
+//               textTransform: "capitalize",
+//               fontWeight: "500",
+//             }}
+//             color="inherit"
+//           >
+//             List
+//           </Typography>
+//         </>
+//       )}
+//       {isListView && (
+//         <>
+//           <Typography
+//             sx={{
+//               fontSize: "16px",
+//               textTransform: "capitalize",
+//               fontWeight: "500",
+//             }}
+//             color="inherit"
+//           >
+//             Map
+//           </Typography>
+//         </>
+//       )}
+//     </SwitchButton>
+//   );
+// }

--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/SwitchViewsButton.js
@@ -1,22 +1,26 @@
 import { Button, Typography, styled } from "@mui/material";
 
-// Override standard button hover behavior
+// Override standard button to keep the background color as white for hover, active, focus states
 const SwitchButton = styled(Button)(({ theme }) => ({
-  background: 'white',
-  color: 'black',
-  border: '#D5D5D6 solid 1px',
-  borderRadius: '10px',
-  boxShadow: 'none',
-  width: '48px',
-  height: '40px',
-  minWidth: '0px',
+  "color": theme.palette.common.black,
+  "backgroundColor": theme.palette.common.white,
+  "border": "#D5D5D6 solid 1px",
+  "borderRadius": "10px",
+  "boxShadow": "none",
+  "width": "48px",
+  "height": "40px",
+  "minWidth": "0px",
+  "maxWidth": "48px",
   "&:hover": {
-    color: "inherit",
-    backgroundColor: "white",
-    boxShadow: 'none'
+    backgroundColor: theme.palette.common.white,
+  },
+  "&:active": {
+    backgroundColor: theme.palette.common.white,
+  },
+  "&:focus": {
+    backgroundColor: theme.palette.common.white,
   },
 }));
-
 
 export default function SwitchViewsButton({ isListView, onClick }) {
   return (
@@ -52,112 +56,3 @@ export default function SwitchViewsButton({ isListView, onClick }) {
     </SwitchButton>
   );
 }
-
-// Proposed Option 1: we use the existing button palette, we can removes styled dependency to simplify the component
-// import { Button, Typography } from "@mui/material";
-
-// export default function SwitchViewsButton({ isListView, onClick }) {
-//   return (
-//     <Button
-//       sx={{
-//         border: "#D5D5D6 solid 1px",
-//         borderRadius: "10px",
-//         boxShadow: "none",
-//         width: "48px",
-//         height: "40px",
-//         minWidth: "0px",
-//       }}
-//       onClick={onClick}
-//     >
-//       {!isListView && (
-//         <>
-//           <Typography
-//             sx={{
-//               fontSize: "16px",
-//               textTransform: "capitalize",
-//               fontWeight: "500",
-//             }}
-//             color="inherit"
-//           >
-//             List
-//           </Typography>
-//         </>
-//       )}
-//       {isListView && (
-//         <>
-//           <Typography
-//             sx={{
-//               fontSize: "16px",
-//               textTransform: "capitalize",
-//               fontWeight: "500",
-//             }}
-//             color="inherit"
-//           >
-//             Map
-//           </Typography>
-//         </>
-//       )}
-//     </Button>
-//   );
-// }
-
-// Proposed Option 2: we modify the hover, active, focus state of this toggle button
-// Override standard button to keep the background color as white for hover, active, focus states
-// import { Button, Typography, styled } from "@mui/material";
-
-// const SwitchButton = styled(Button)(({ theme }) => ({
-//   color: theme.palette.common.black,
-//   backgroundColor: theme.palette.common.white,
-//   border: "#D5D5D6 solid 1px",
-//   borderRadius: "10px",
-//   boxShadow: "none",
-//   width: "48px",
-//   height: "40px",
-//   minWidth: "0px",
-//   "&:hover": {
-//     backgroundColor: theme.palette.common.white,
-//   },
-//   "&:active": {
-//     backgroundColor: theme.palette.common.white,
-//     boxShadow: "inset 0px 8px 4px rgba(0,0,0,0.24)",
-//   },
-//   "&:focus": {
-//     backgroundColor: theme.palette.common.white,
-//     filter: "drop-shadow(0px 0px 12px rgba(255, 255, 255, 0.8))",
-//   },
-// }));
-
-// export default function SwitchViewsButton({ isListView, onClick }) {
-//   return (
-//     <SwitchButton onClick={onClick}>
-//       {!isListView && (
-//         <>
-//           <Typography
-//             sx={{
-//               fontSize: "16px",
-//               textTransform: "capitalize",
-//               fontWeight: "500",
-//             }}
-//             color="inherit"
-//           >
-//             List
-//           </Typography>
-//         </>
-//       )}
-//       {isListView && (
-//         <>
-//           <Typography
-//             sx={{
-//               fontSize: "16px",
-//               textTransform: "capitalize",
-//               fontWeight: "500",
-//             }}
-//             color="inherit"
-//           >
-//             Map
-//           </Typography>
-//         </>
-//       )}
-//     </SwitchButton>
-//   );
-// }


### PR DESCRIPTION
Style `SwitchViewsButton` component

**Current Styling:**

https://github.com/hackforla/food-oasis/assets/68657634/00ddd08d-2ea9-49e6-a42c-6f0f86f692c8


**proposed option 1 styling:**
- uses the existing button palette, and removes styled dependency to simplify the component

https://github.com/hackforla/food-oasis/assets/68657634/8cf403c8-66f9-4df2-965f-ae156be946f8



**proposed option 2 styling:**
- modifies the hover, active, focus state to keep the background color as white

https://github.com/hackforla/food-oasis/assets/68657634/c2ce2d42-5ae4-40b6-b9ac-14f509c66ce5

