### PR TITLE
Configured different tenant regions for email

### DIFF
--- a/client/src/components/StaticPages/Contact.js
+++ b/client/src/components/StaticPages/Contact.js
@@ -17,6 +17,7 @@ import { sendContactForm } from "services/contact-service";
 import * as Yup from "yup";
 import * as analytics from "../../services/analytics";
 import Footer from "../Layout/Footer";
+import { useSiteContext } from "contexts/siteContext";
 
 const validationSchema = Yup.object().shape({
   name: Yup.string().required("Please enter your name"),
@@ -96,6 +97,7 @@ const Contact = () => {
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   const { isMobile } = useBreakpoints();
+  const { tenantId } = useSiteContext();
 
   const navigate = useNavigate();
 
@@ -161,6 +163,7 @@ const Contact = () => {
                 phone: "",
                 title: "",
                 message: "",
+                tenantId,
               }}
               validationSchema={validationSchema}
               onSubmit={(values) => {

--- a/client/src/services/contact-service.js
+++ b/client/src/services/contact-service.js
@@ -4,6 +4,9 @@ const baseUrl = "/api/emails/contact";
 const clientUrl = window.location.origin;
 
 export const sendContactForm = async (formData) => {
-  const response = await axios.post(baseUrl, { ...formData, clientUrl });
+  const response = await axios.post(baseUrl, {
+    ...formData,
+    clientUrl,
+  });
   return response.data;
 };

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -4,7 +4,7 @@ import { ContactFormData, Email } from "../../types/email-type";
 
 const emailUser: string = process.env.EMAIL_USER || "";
 const sendgridKey: string = process.env.SENDGRID_API_KEY || "";
-const staffEmail: string = process.env.CONTACT_US_EMAIL || "";
+
 sgMail.setApiKey(sendgridKey);
 
 const send = async (email: Email) => {
@@ -119,8 +119,19 @@ const sendContactEmail = async ({
   title,
   message,
   clientUrl,
+  tenantId,
   phone,
 }: ContactFormData) => {
+
+  const tenantRegions: { [key: number]: string } = {
+    1: process.env.CONTACT_US_LA || "",
+    3: process.env.CONTACT_US_HAWAII || "",
+    5: process.env.CONTACT_US_LA || "",
+    6: process.env.CONTACT_US_LA || "",
+  };
+
+  const staffEmail: string = tenantId ? tenantRegions[tenantId] : "";
+
   const emailBody = `
   <p
   style="
@@ -462,6 +473,7 @@ const sendContactEmail = async ({
   return sgMail.send(msg, false, (err) => {
     if (err) {
       Promise.reject("Sending contact form email failed.");
+      console.log("ERRR", err);
     }
     Promise.resolve(true).then(() => {
       if (email) {

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -497,8 +497,7 @@ const sendContactConfirmation = async ({
   title,
   message,
   clientUrl,
-}: // phone,
-ContactFormData) => {
+}: ContactFormData) => {
   const now = new Date();
   const dateString: string = now.toLocaleString("en-US", {
     weekday: "long",

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -124,10 +124,10 @@ const sendContactEmail = async ({
 }: ContactFormData) => {
 
   const tenantRegions: { [key: number]: string } = {
-    1: process.env.CONTACT_US_LA || "",
-    3: process.env.CONTACT_US_HAWAII || "",
-    5: process.env.CONTACT_US_LA || "",
-    6: process.env.CONTACT_US_LA || "",
+    1: process.env.CONTACT_US_LA || "", // LA
+    3: process.env.CONTACT_US_HAWAII || "", // Hawaii
+    5: process.env.CONTACT_US_LA || "", // Texas
+    6: process.env.CONTACT_US_LA || "", // Santa Barbara
   };
 
   const staffEmail: string = tenantId ? tenantRegions[tenantId] : "";

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -473,7 +473,6 @@ const sendContactEmail = async ({
   return sgMail.send(msg, false, (err) => {
     if (err) {
       Promise.reject("Sending contact form email failed.");
-      console.log("ERRR", err);
     }
     Promise.resolve(true).then(() => {
       if (email) {

--- a/server/types/email-type.ts
+++ b/server/types/email-type.ts
@@ -9,6 +9,7 @@ export interface ContactFormData {
   name: string;
   message: string;
   clientUrl: string;
+  tenantId?: number;
   email?: string;
   title?: string;
   phone?: string;


### PR DESCRIPTION
Closes #1774 

Added tenant Id configuration to the contact email sending function. So now users can send emails to either Hawaii or LA depending on their region. 

For this to work, the secrets must be updated. Please add:
```

# Contact form emails
CONTACT_US_LA=foodoasis@hackforla.org
CONTACT_US_HAWAII=info@alohaharvest.org
```

to your server .env file. 