### PR TITLE
Fixed timezones depending on FO region emailed from 

### DIFF
--- a/client/src/components/StaticPages/Contact.js
+++ b/client/src/components/StaticPages/Contact.js
@@ -17,6 +17,7 @@ import { sendContactForm } from "services/contact-service";
 import * as Yup from "yup";
 import * as analytics from "../../services/analytics";
 import Footer from "../Layout/Footer";
+import { useSiteContext } from "contexts/siteContext";
 
 const validationSchema = Yup.object().shape({
   name: Yup.string().required("Please enter your name"),
@@ -96,6 +97,7 @@ const Contact = () => {
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   const { isMobile } = useBreakpoints();
+  const { tenantId } = useSiteContext();
 
   const navigate = useNavigate();
 
@@ -161,6 +163,7 @@ const Contact = () => {
                 phone: "",
                 title: "",
                 message: "",
+                tenantId,
               }}
               validationSchema={validationSchema}
               onSubmit={(values) => {

--- a/client/src/services/contact-service.js
+++ b/client/src/services/contact-service.js
@@ -4,6 +4,9 @@ const baseUrl = "/api/emails/contact";
 const clientUrl = window.location.origin;
 
 export const sendContactForm = async (formData) => {
-  const response = await axios.post(baseUrl, { ...formData, clientUrl });
+  const response = await axios.post(baseUrl, {
+    ...formData,
+    clientUrl,
+  });
   return response.data;
 };

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -4,7 +4,7 @@ import { ContactFormData, Email } from "../../types/email-type";
 
 const emailUser: string = process.env.EMAIL_USER || "";
 const sendgridKey: string = process.env.SENDGRID_API_KEY || "";
-const staffEmail: string = process.env.CONTACT_US_EMAIL || "";
+
 sgMail.setApiKey(sendgridKey);
 
 const send = async (email: Email) => {
@@ -119,8 +119,19 @@ const sendContactEmail = async ({
   title,
   message,
   clientUrl,
+  tenantId,
   phone,
 }: ContactFormData) => {
+
+  const tenantRegions: { [key: number]: string } = {
+    1: process.env.CONTACT_US_LA || "",
+    3: process.env.CONTACT_US_HAWAII || "",
+    5: process.env.CONTACT_US_LA || "",
+    6: process.env.CONTACT_US_LA || "",
+  };
+
+  const staffEmail: string = tenantId ? tenantRegions[tenantId] : "";
+
   const emailBody = `
   <p
   style="
@@ -462,6 +473,7 @@ const sendContactEmail = async ({
   return sgMail.send(msg, false, (err) => {
     if (err) {
       Promise.reject("Sending contact form email failed.");
+      console.log("ERRR", err);
     }
     Promise.resolve(true).then(() => {
       if (email) {

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -515,7 +515,7 @@ const sendContactConfirmation = async ({
     day: "numeric",
   });
 
-  const time = now.toLocaleTimeString("en-US", { timeZone: tenantId ? timeZones[tenantId] : "America/Los_Angeles"});
+  const time = now.toLocaleTimeString("en-US", { timeZone: tenantId ? timeZones[tenantId] : "America/Los_Angeles", timeZoneName: 'short'});
 
   const emailBody = `
   <!DOCTYPE html>
@@ -584,7 +584,7 @@ const sendContactConfirmation = async ({
                 <td width="25%" style="padding: 10px 10px 10px 0"><strong>Date:</strong> ${dateString}</td>
               </tr>
               <tr>
-                <td width="25%" style="padding: 10px 10px 10px 0"><strong>Time:</strong> ${time} PST</td>
+                <td width="25%" style="padding: 10px 10px 10px 0"><strong>Time:</strong> ${time}</td>
               </tr>
               <tr>
                 <td width="25%" style="padding: 10px 10px 10px 0"><strong>Subject:</strong> ${

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -482,6 +482,7 @@ const sendContactEmail = async ({
           title,
           message,
           clientUrl,
+          tenantId,
           phone,
         });
       }
@@ -495,18 +496,26 @@ const sendContactConfirmation = async ({
   email,
   title,
   message,
+  tenantId,
   clientUrl,
 }: ContactFormData) => {
   const now = new Date();
+
+  const timeZones: { [key: number]: string } = {
+    1: "America/Los_Angeles", // LA
+    3: "Pacific/Honolulu", // Hawaii
+    5: "US/Central", // Texas
+    6: "America/Los_Angeles", // Santa Barbara
+  };
+
   const dateString: string = now.toLocaleString("en-US", {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
-    timeZone: "America/Los_Angeles",
   });
 
-  const time = now.toLocaleTimeString();
+  const time = now.toLocaleTimeString("en-US", { timeZone: tenantId ? timeZones[tenantId] : "America/Los_Angeles"});
 
   const emailBody = `
   <!DOCTYPE html>

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -473,7 +473,6 @@ const sendContactEmail = async ({
   return sgMail.send(msg, false, (err) => {
     if (err) {
       Promise.reject("Sending contact form email failed.");
-      console.log("ERRR", err);
     }
     Promise.resolve(true).then(() => {
       if (email) {
@@ -497,8 +496,7 @@ const sendContactConfirmation = async ({
   title,
   message,
   clientUrl,
-}: // phone,
-ContactFormData) => {
+}: ContactFormData) => {
   const now = new Date();
   const dateString: string = now.toLocaleString("en-US", {
     weekday: "long",

--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -124,10 +124,10 @@ const sendContactEmail = async ({
 }: ContactFormData) => {
 
   const tenantRegions: { [key: number]: string } = {
-    1: process.env.CONTACT_US_LA || "",
-    3: process.env.CONTACT_US_HAWAII || "",
-    5: process.env.CONTACT_US_LA || "",
-    6: process.env.CONTACT_US_LA || "",
+    1: process.env.CONTACT_US_LA || "", // LA
+    3: process.env.CONTACT_US_HAWAII || "", // Hawaii
+    5: process.env.CONTACT_US_LA || "", // Texas
+    6: process.env.CONTACT_US_LA || "", // Santa Barbara
   };
 
   const staffEmail: string = tenantId ? tenantRegions[tenantId] : "";

--- a/server/types/email-type.ts
+++ b/server/types/email-type.ts
@@ -9,6 +9,7 @@ export interface ContactFormData {
   name: string;
   message: string;
   clientUrl: string;
+  tenantId?: number;
   email?: string;
   title?: string;
   phone?: string;


### PR DESCRIPTION
Closes #2016 

Currently when a user sends an email through the contact form and gets a confirmation email, it shows the timezone in PST no matter which region they emailed. This changes it so the timezone will reflect the region they emailed. 

Example for TX: 


![timescreenshot](https://github.com/hackforla/food-oasis/assets/8907997/63ec1e50-b32d-4be7-8d25-685821ba7460)
