### PR TITLE
 Fixed timezones depending on FO region emailed from #2017 

### DIFF
--- a/server/app/services/sendgrid-service.ts
+++ b/server/app/services/sendgrid-service.ts
@@ -482,6 +482,7 @@ const sendContactEmail = async ({
           title,
           message,
           clientUrl,
+          tenantId,
           phone,
         });
       }
@@ -495,18 +496,26 @@ const sendContactConfirmation = async ({
   email,
   title,
   message,
+  tenantId,
   clientUrl,
 }: ContactFormData) => {
   const now = new Date();
+
+  const timeZones: { [key: number]: string } = {
+    1: "America/Los_Angeles", // LA
+    3: "Pacific/Honolulu", // Hawaii
+    5: "US/Central", // Texas
+    6: "America/Los_Angeles", // Santa Barbara
+  };
+
   const dateString: string = now.toLocaleString("en-US", {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
-    timeZone: "America/Los_Angeles",
   });
 
-  const time = now.toLocaleTimeString();
+  const time = now.toLocaleTimeString("en-US", { timeZone: tenantId ? timeZones[tenantId] : "America/Los_Angeles", timeZoneName: 'short'});
 
   const emailBody = `
   <!DOCTYPE html>
@@ -575,7 +584,7 @@ const sendContactConfirmation = async ({
                 <td width="25%" style="padding: 10px 10px 10px 0"><strong>Date:</strong> ${dateString}</td>
               </tr>
               <tr>
-                <td width="25%" style="padding: 10px 10px 10px 0"><strong>Time:</strong> ${time} PST</td>
+                <td width="25%" style="padding: 10px 10px 10px 0"><strong>Time:</strong> ${time}</td>
               </tr>
               <tr>
                 <td width="25%" style="padding: 10px 10px 10px 0"><strong>Subject:</strong> ${


### PR DESCRIPTION
Closes #2016

Currently when a user sends an email through the contact form and gets a confirmation email, it shows the timezone in PST no matter which region they emailed. This changes it so the timezone will reflect the region they emailed.

Example for TX:

![timescreenshot](https://github.com/hackforla/food-oasis/assets/8907997/6a6ea797-0f9f-436c-83bf-1575c66d0346)
