### PR TITLE
updates main to heroku deployment github action to remove warnings

### DIFF
--- a/.github/workflows/mainToHeroku.yml
+++ b/.github/workflows/mainToHeroku.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.8.9 # This is the action
+      - uses: actions/checkout@v3
+      - uses: akhileshns/heroku-deploy@v3.12.14 # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: "foodoasis" #Must be unique in Heroku


### PR DESCRIPTION
- updating actions/checkout from v2 to v3
-  updating heroku action from 3.8.9 to 3.12.14