### PR TITLE
2075 stakeholder preview shadow fix

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
@@ -196,7 +196,9 @@ const StakeholderPreview = ({ stakeholder, onSelect, isDesktop }) => {
         minHeight: "6rem",
         padding: isDesktop ? "1.5rem 2.625rem" : "1.5rem 0",
         margin: "14px 23px",
-        "&:hover": { boxShadow: isDesktop ? 3 : 0 },
+        "&:hover": {
+          boxShadow: isDesktop ? "0 4px 20px rgb(0 22 100 / 20%)" : 0,
+        },
         borderRadius: 2,
       }}
     >

--- a/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
@@ -199,7 +199,7 @@ const StakeholderPreview = ({ stakeholder, onSelect, isDesktop }) => {
         "&:hover": {
           boxShadow: isDesktop ? "0 4px 20px rgb(0 22 100 / 20%)" : 0,
         },
-        borderRadius: 2,
+        borderRadius: "10px",
       }}
     >
       <Grid2


### PR DESCRIPTION
Closes #2075 

Shadow hover effect now matches the Figma file
https://www.figma.com/file/9hPmNSsyaH2VMGNz5mffmI/FOLA-Design-%232?type=design&node-id=6875-9580&mode=design&t=e7Hvz2NsOuBzev6r-0

Before:
![chrome_QRdGC5deS8](https://github.com/hackforla/food-oasis/assets/86622025/52e27faf-06b8-44cc-8a1e-d17d05f7749e)

After:
![chrome_rzwkAwkjxG](https://github.com/hackforla/food-oasis/assets/86622025/67cb5e3b-bdbc-4de2-bebc-41e933dd32b0)
