### PR TITLE
change z-index for list

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/layouts/Desktop.js
+++ b/client/src/components/FoodSeeker/SearchResults/layouts/Desktop.js
@@ -84,7 +84,7 @@ const DesktopLayout = ({ filters, list, map }) => {
             left: isListPanelOpen ? leftPostion : "-524px",
             top: "120px",
             height: "calc(100% - 120px)",
-            zIndex: "1",
+            zIndex: 3,
             background: "white",
           }}
         >


### PR DESCRIPTION
closes #2084 
closes #2070 

Before Mapbox logo shows above list.
<img width="419" alt="image" src="https://github.com/hackforla/food-oasis/assets/60997220/6f77bf2b-1e57-4f3b-bfc7-d1af439b4158">
After logo stays behind list
<img width="442" alt="image" src="https://github.com/hackforla/food-oasis/assets/60997220/cc5c8ddc-1f2e-4139-9c53-0ce581eefa99">


