### PR TITLE
remove buttons behind feature flag

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/ResultsFilters.js
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/ResultsFilters.js
@@ -13,6 +13,7 @@ import * as analytics from "services/analytics";
 import { tenantDetails } from "../../../../helpers/Configuration";
 import CategoryButton from "./CategoryButton";
 import SwitchViewsButton from "./SwitchViewsButton";
+import useFeatureFlag from "hooks/useFeatureFlag";
 
 const ResultsFilters = ({
   categoryIds,
@@ -26,6 +27,7 @@ const ResultsFilters = ({
   const { getUserLocation } = useGeolocation();
   const locationPermission = useLocationPermission();
   const [error, setError] = useState("");
+  const hasAdvancedFilterFeatureFlag = useFeatureFlag("advancedFilter");
 
   useEffect(() => {
     if (error && locationPermission === "granted") {
@@ -98,31 +100,34 @@ const ResultsFilters = ({
             alignItems: "center",
           }}
         >
-          <Grid2
-            container
-            xs={12}
-            sm={6}
-            spacing={1}
-            justifyContent={{ xs: "center", sm: "flex-start" }}
-          >
-            <Grid2 item>
-              <CategoryButton
-                icon="pantry"
-                onClick={togglePantry}
-                label="Pantries"
-                isSelected={isPantrySelected}
-              />
+          {!hasAdvancedFilterFeatureFlag && (
+            <Grid2
+              container
+              xs={12}
+              sm={6}
+              spacing={1}
+              justifyContent={{ xs: "center", sm: "flex-start" }}
+            >
+              <Grid2 item>
+                <CategoryButton
+                  icon="pantry"
+                  onClick={togglePantry}
+                  label="Pantries"
+                  isSelected={isPantrySelected}
+                />
+              </Grid2>
+              <Grid2 item>
+                <CategoryButton
+                  icon="meal"
+                  onClick={toggleMeal}
+                  label="Meals"
+                  isSelected={isMealsSelected}
+                  style={{ marginLeft: 5 }}
+                />
+              </Grid2>
             </Grid2>
-            <Grid2 item>
-              <CategoryButton
-                icon="meal"
-                onClick={toggleMeal}
-                label="Meals"
-                isSelected={isMealsSelected}
-                style={{ marginLeft: 5 }}
-              />
-            </Grid2>
-          </Grid2>
+          )}
+
           <Grid2 xs={12} sm={6}>
             <Stack
               direction="row"


### PR DESCRIPTION
Users behind advancedFlag feature flag will not see 'Pantries' and 'Meals' buttons. If your account is flagged for this feature, please login first. 

Details: 
In this update, I've utilized feature flags to control the visibility of the 'Pantries' and 'Meals' buttons, which the advanceFilter feature is set to replace. Given that advanceFilter is still in development and not ready for release, employing feature flags ensures that users do not encounter a gap in functionality. 