### PR TITLE
bug: no hours on stakeholder details

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.js
@@ -395,7 +395,7 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
 
                 <Box textAlign="left" sx={{ marginTop: "16px" }}>
                   {selectedOrganization.hours &&
-                  selectedOrganization.hours > 0 ? (
+                  selectedOrganization.hours.length > 0 ? (
                     <Typography>
                       Open{" "}
                       {nextOpenTime(


### PR DESCRIPTION
Bug Fix: The Stakeholder Details page was showing  "No hours on record" when there was hours.

Before:
![chrome_3T1JugAILs](https://github.com/hackforla/food-oasis/assets/86622025/e16dadaa-1b2d-481a-99ca-fe1e5586857f)

Hours:
![chrome_lN1iwjkLMP](https://github.com/hackforla/food-oasis/assets/86622025/98690297-7189-4a02-8656-daded026ef25)
