### PR TITLE
2109 update text color of stakeholder details 'updated on' text

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.js
@@ -730,7 +730,7 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
 
                 {selectedOrganization.verificationStatusId ===
                 VERIFICATION_STATUS.VERIFIED ? (
-                  <DetailText color="secondary.main">
+                  <DetailText>
                     Data updated on{" "}
                     {selectedOrganization.approvedDate
                       ? formatDateMMMddYYYY(selectedOrganization.approvedDate)


### PR DESCRIPTION
Closes #2109

The text color is no longer orange.

<img width="369" alt="Screen Shot 2024-04-09 at 6 47 37 PM" src="https://github.com/hackforla/food-oasis/assets/86622025/ca20204f-b70f-41af-849b-04273d661214">
