### PR TITLE
2045 remove redundant tooltip

### DIFF
--- a/client/src/components/FoodSeeker/Home.js
+++ b/client/src/components/FoodSeeker/Home.js
@@ -73,9 +73,9 @@ const Home = () => {
   };
 
   useEffect(() => {
-    const loadingSpinner = document.getElementById('home-loading-spinner');
+    const loadingSpinner = document.getElementById("home-loading-spinner");
     if (loadingSpinner) {
-      loadingSpinner.style.display = 'none';
+      loadingSpinner.style.display = "none";
     }
   }, []);
 
@@ -206,9 +206,8 @@ const Home = () => {
                   <div style={{ textAlign: "center" }}>
                     <Tooltip
                       title={
-                        locationPermission === "denied" || !!error
-                          ? "Please allow location access"
-                          : "Use my current location"
+                        (locationPermission === "denied" || !!error) &&
+                        "Please allow location access"
                       }
                     >
                       <div>

--- a/client/src/components/FoodSeeker/Home.js
+++ b/client/src/components/FoodSeeker/Home.js
@@ -205,6 +205,7 @@ const Home = () => {
                 ) : (
                   <div style={{ textAlign: "center" }}>
                     <Tooltip
+                      enterTouchDelay={0}
                       title={
                         (locationPermission === "denied" || !!error) &&
                         "Please allow location access"


### PR DESCRIPTION
Closes #2045 

Removed the redundant "use my current location" tooltip, but kept the tooltip when your location is disabled:

![chrome_JikjW8F4ou](https://github.com/hackforla/food-oasis/assets/86622025/8b01abb8-c3c2-4a9f-a290-48c591873112)

![chrome_bPLmgwyMPK](https://github.com/hackforla/food-oasis/assets/86622025/502ddd02-1828-4fdc-87cd-bed5b747a14c)
