### PR TITLE
Added Twitter Validation and Tool tip #2184

### DIFF
--- a/client/src/components/Admin/OrganizationEdit.js
+++ b/client/src/components/Admin/OrganizationEdit.js
@@ -51,6 +51,12 @@ const validationSchema = Yup.object().shape({
   longitude: Yup.number().required("Longitude is required").min(-180).max(180),
   email: Yup.string().email("Invalid email address format"),
   hours: Yup.array().of(HourSchema),
+  twitter: Yup.string()
+    .matches(
+      /^https?:\/\/(www\.)?(twitter\.com|x\.com)\/.*/,
+      "Invalid URL, e.g. 'https://twitter.com/ or https://x.com/'"
+    )
+    .required("Full Twitter/X URL is required."),
   selectedCategoryIds: Yup.array().min(
     1,
     "You must select at least one category"

--- a/client/src/components/Admin/OrganizationEdit/ContactDetails.js
+++ b/client/src/components/Admin/OrganizationEdit/ContactDetails.js
@@ -64,7 +64,13 @@ export default function ContactDetails({
         </Grid>
         <Grid item sm={6} xs={12}>
           <div>
-            <Label id="twitter" label="Twitter" />
+            <Label
+              id="twitter"
+              label="Twitter"
+              tooltipTitle="URL must start with 'https://twitter.com/ or https://x.com/'"
+              href={values.twitter}
+            />
+
             <TextField
               id="twitter"
               name="twitter"

--- a/client/src/components/Admin/ui/Label.js
+++ b/client/src/components/Admin/ui/Label.js
@@ -1,4 +1,5 @@
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import LaunchIcon from "@mui/icons-material/Launch";
 import {
   ClickAwayListener,
   IconButton,
@@ -6,11 +7,13 @@ import {
   Stack,
   Tooltip,
   Typography,
+  Button,
+  Link,
 } from "@mui/material";
 import { useState } from "react";
 import { tooltipHover } from "theme/palette";
 
-const Label = ({ id, label, tooltipTitle }) => {
+const Label = ({ id, label, tooltipTitle, href }) => {
   const [tooltipOpen, setTooltipOpen] = useState(false);
 
   const handleToolTipToggle = () => {
@@ -19,24 +22,46 @@ const Label = ({ id, label, tooltipTitle }) => {
 
   return (
     <InputLabel htmlFor={id}>
-      <Stack direction="row" alignItems="center" height="40px">
-        <Typography fontWeight={600}>{label}</Typography>
-        {tooltipTitle && (
-          <ClickAwayListener onClickAway={() => setTooltipOpen(false)}>
-            <Tooltip
-              title={tooltipTitle}
-              open={tooltipOpen}
-              arrow
-              placement="top-start"
-            >
-              <IconButton
-                sx={{ "&:hover": { backgroundColor: tooltipHover } }}
-                onClick={() => handleToolTipToggle()}
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        height="40px"
+        justifyContent="space-between"
+      >
+        <Stack direction="row" alignItems="center">
+          <Typography fontWeight={600}>{label}</Typography>
+          {tooltipTitle && (
+            <ClickAwayListener onClickAway={() => setTooltipOpen(false)}>
+              <Tooltip
+                title={tooltipTitle}
+                open={tooltipOpen}
+                arrow
+                placement="top-start"
               >
-                <InfoOutlinedIcon />
-              </IconButton>
-            </Tooltip>
-          </ClickAwayListener>
+                <IconButton
+                  sx={{ "&:hover": { backgroundColor: tooltipHover } }}
+                  onClick={() => handleToolTipToggle()}
+                >
+                  <InfoOutlinedIcon />
+                </IconButton>
+              </Tooltip>
+            </ClickAwayListener>
+          )}
+        </Stack>
+
+        {href && (
+          <Button
+            variant="text"
+            size="small"
+            sx={{ textTransform: "none" }}
+            rel="noopener"
+            component={Link}
+            href={href}
+            startIcon={<LaunchIcon />}
+          >
+            Go To Link
+          </Button>
         )}
       </Stack>
     </InputLabel>


### PR DESCRIPTION
Closes #2184 

I added validation and a tool tip for the twitter field in the contact details.

Since twitter is now called X, I made it both accept http://twitter.com/ or http:// x.com/ and it will accept any username they enter after.

it also accepts http:// or https:// and www is optional. 

My question would be if it must start with https:// or http:// or can they write 
twitter.com/username or x.com/username ?

I would need to change it, if that is an option you guys want to add

Thank you!


here is a video that explains what I have written above. sound on to hear explanation or you can just view the video 

https://github.com/user-attachments/assets/a7e56208-32cf-4e31-8452-958d3c3476a5

