### PR TITLE
Feature: Toast prompt for user feedback form

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mapbox/geo-viewport": "^0.4.1",
-        "@mui/icons-material": "^5.16.4",
+        "@mui/icons-material": "^5.16.7",
         "@mui/lab": "^5.0.0-alpha.113",
         "@mui/material": "^5.11.1",
         "@mui/x-data-grid": "^5.17.20",
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.4.tgz",
-      "integrity": "sha512-j9/CWctv6TH6Dou2uR2EH7UOgu79CW/YcozxCYVLJ7l03pCsiOlJ5sBArnWJxJ+nGkFwyL/1d1k8JEPMDR125A==",
+      "version": "5.16.7",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.7.tgz",
+      "integrity": "sha512-UrGwDJCXEszbDI7yV047BYU5A28eGJ79keTCP4cc74WyncuVrnurlmIRxaHL8YK+LI1Kzq+/JM52IAkNnv4u+Q==",
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mapbox/geo-viewport": "^0.4.1",
-    "@mui/icons-material": "^5.16.4",
+    "@mui/icons-material": "^5.16.7",
     "@mui/lab": "^5.0.0-alpha.113",
     "@mui/material": "^5.11.1",
     "@mui/x-data-grid": "^5.17.20",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,8 +1,9 @@
-import { CssBaseline } from "@mui/material";
+import { CssBaseline, Snackbar } from "@mui/material";
+import SurveySnackbar from "./components/UI/SurveySnackbar";
 import { SiteProvider } from "contexts/siteContext";
 import { ToasterProvider } from "contexts/toasterContext";
 import { UserProvider } from "contexts/userContext";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { HelmetProvider } from "react-helmet-async";
 import { BrowserRouter as Router } from "react-router-dom";
 import { ThemeProvider } from "theme";
@@ -16,6 +17,18 @@ function App() {
   useEffect(() => {
     analytics.postEvent("visitAppComponent");
   }, []);
+
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+
+  const handleOpenSnackbar = (message) => {
+    setSnackbarMessage(message);
+    setSnackbarOpen(true);
+  };
+
+  const handleCloseSnackbar = () => {
+    setSnackbarOpen(false);
+  };
 
   return (
     <HelmetProvider>
@@ -33,6 +46,12 @@ function App() {
                 <MapProvider>
                   <Router>
                     <AppRoutes />
+                    <SurveySnackbar
+                      open={snackbarOpen}
+                      autoHideDuration={6000}
+                      onClose={handleCloseSnackbar}
+                      message={snackbarMessage}
+                    />
                   </Router>
                 </MapProvider>
               </ThemeProvider>

--- a/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
@@ -1,4 +1,12 @@
-import { Box, Button, Chip, Divider, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Chip,
+  Divider,
+  Snackbar,
+  Stack,
+  Typography,
+} from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2";
 import {
   FOOD_PANTRY_CATEGORY_ID,
@@ -191,6 +199,10 @@ const StakeholderPreview = ({ stakeholder, onSelect, isDesktop }) => {
               component="h2"
               align="left"
               fontWeight="bold"
+              sx={{
+                color: { xs: "black", md: "inherit" },
+                textDecoration: { xs: "underline", md: "none" },
+              }}
               onClick={() => handleSelectOrganization(stakeholder)}
             >
               {stakeholder.name}
@@ -199,7 +211,9 @@ const StakeholderPreview = ({ stakeholder, onSelect, isDesktop }) => {
               direction="row"
               flexWrap="wrap"
               marginTop="8px"
-              sx={{ gap: "16px" }}
+              sx={{
+                gap: "16px",
+              }}
               onClick={() => handleSelectOrganization(stakeholder)}
             >
               {stakeholder.categories

--- a/client/src/components/UI/SurveySnackbar.js
+++ b/client/src/components/UI/SurveySnackbar.js
@@ -1,0 +1,176 @@
+import * as React from "react";
+import { useState } from "react";
+import { IconButton, Collapse, Button } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import Stack from "@mui/material/Stack";
+import Snackbar from "@mui/material/Snackbar";
+import Box from "@mui/material/Box";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { margin } from "@mui/system";
+
+const SurveySnackbar = () => {
+  const [open, setOpen] = useState(() => {
+    const isClosed = localStorage.getItem("surveySnackbarClosed");
+    return isClosed !== "true";
+  });
+  const [expanded, setExpanded] = useState(false);
+
+  const handleClose = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+    localStorage.setItem("surveySnackbarClosed", "true");
+  };
+
+  const toggleExpansion = () => {
+    setExpanded((prevExpanded) => !prevExpanded);
+  };
+
+  const openForm = () => {
+    window.open(
+      "https://docs.google.com/forms/d/e/1FAIpQLSdAhi_nMKQfWVHjfpl1ZkmymBTt8BW7YNqVIOJ4JKYgSL4O3g/viewform",
+      "_blank"
+    );
+  };
+
+  const labelStyles = {
+    marginBottom: "10px",
+    display: "block",
+  };
+
+  const inputStyles = {
+    marginRight: "5px",
+  };
+
+  const action = (
+    <Box
+      onClick={toggleExpansion}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        width: "320px",
+        cursor: "pointer",
+      }}
+    >
+      <span> Participate in a quick survey</span>
+
+      <IconButton
+        variant="contained"
+        aria-label={expanded ? "Collapse" : "Expand"}
+        sx={{
+          color: "white",
+          backgroundColor: "#323232",
+          borderRadius: "5px",
+          "&:hover": {
+            backgroundColor: "#323232",
+          },
+        }}
+      >
+        {expanded ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+      </IconButton>
+    </Box>
+  );
+
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 700 }}>
+      <Snackbar
+        open={open}
+        onClose={handleClose}
+        action={action}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        sx={{
+          "& .MuiSnackbar-root": {
+            width: "100%",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            backgroundColor: "#323232",
+            color: "white",
+            padding: 2,
+            borderRadius: 1,
+          }}
+        >
+          <Box>{action}</Box>
+          <Collapse
+            in={expanded}
+            timeout="auto"
+            style={{ margin: "0 0 10px 0" }}
+            unmountOnExit
+          >
+            <Box sx={{ mt: 2 }}>
+              <p style={{ margin: "0 0 20px 0", fontWeight: "800" }}>
+                What brought you to Food Oasis today?
+              </p>
+              <div onClick={openForm} style={{ cursor: "pointer" }}>
+                <label style={labelStyles}>
+                  <input
+                    style={inputStyles}
+                    type="checkbox"
+                    name="option"
+                    value="myself"
+                  />
+                  Looking for myself
+                </label>
+                <label style={labelStyles}>
+                  <input
+                    style={inputStyles}
+                    type="checkbox"
+                    name="option"
+                    value="friend-family"
+                  />
+                  Looking for a friend/family member
+                </label>
+                <label style={labelStyles}>
+                  <input
+                    style={inputStyles}
+                    type="checkbox"
+                    name="option"
+                    value="social-worker"
+                  />
+                  I'm a social worker looking for a client
+                </label>
+                <label style={labelStyles}>
+                  <input
+                    style={inputStyles}
+                    type="checkbox"
+                    name="option"
+                    value="volunteer"
+                  />
+                  Food Oasis volunteer
+                </label>
+                <label style={labelStyles}>
+                  <input
+                    style={inputStyles}
+                    type="checkbox"
+                    name="option"
+                    value="other"
+                  />
+                  Other
+                </label>
+              </div>
+
+              <div
+                className="survey-buttons"
+                style={{
+                  display: "flex",
+                  justifyContent: "space-evenly",
+                  margin: "30px 0 0 0",
+                }}
+              >
+                <Button onClick={openForm}> Complete Survey </Button>
+                <Button onClick={handleClose}> Close </Button>
+              </div>
+            </Box>
+          </Collapse>
+        </Box>
+      </Snackbar>
+    </Stack>
+  );
+};
+
+export default SurveySnackbar;

--- a/client/src/components/UI/SurveySnackbar.js
+++ b/client/src/components/UI/SurveySnackbar.js
@@ -1,20 +1,16 @@
 import * as React from "react";
 import { useState } from "react";
-import { IconButton, Collapse, Button } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
+import { Button } from "@mui/material";
+
 import Stack from "@mui/material/Stack";
 import Snackbar from "@mui/material/Snackbar";
 import Box from "@mui/material/Box";
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { margin } from "@mui/system";
 
 const SurveySnackbar = () => {
   const [open, setOpen] = useState(() => {
     const isClosed = localStorage.getItem("surveySnackbarClosed");
     return isClosed !== "true";
   });
-  const [expanded, setExpanded] = useState(false);
 
   const handleClose = (event, reason) => {
     if (reason === "clickaway") {
@@ -24,10 +20,6 @@ const SurveySnackbar = () => {
     localStorage.setItem("surveySnackbarClosed", "true");
   };
 
-  const toggleExpansion = () => {
-    setExpanded((prevExpanded) => !prevExpanded);
-  };
-
   const openForm = () => {
     window.open(
       "https://docs.google.com/forms/d/e/1FAIpQLSdAhi_nMKQfWVHjfpl1ZkmymBTt8BW7YNqVIOJ4JKYgSL4O3g/viewform",
@@ -35,42 +27,19 @@ const SurveySnackbar = () => {
     );
   };
 
-  const labelStyles = {
-    marginBottom: "10px",
-    display: "block",
-  };
-
-  const inputStyles = {
-    marginRight: "5px",
-  };
-
   const action = (
     <Box
-      onClick={toggleExpansion}
       sx={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        width: "320px",
+        width: "520px",
         cursor: "pointer",
       }}
     >
       <span> Participate in a quick survey</span>
-
-      <IconButton
-        variant="contained"
-        aria-label={expanded ? "Collapse" : "Expand"}
-        sx={{
-          color: "white",
-          backgroundColor: "#323232",
-          borderRadius: "5px",
-          "&:hover": {
-            backgroundColor: "#323232",
-          },
-        }}
-      >
-        {expanded ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-      </IconButton>
+      <Button onClick={openForm}> Complete Survey </Button>
+      <Button onClick={handleClose}> OPT OUT </Button>
     </Box>
   );
 
@@ -96,77 +65,6 @@ const SurveySnackbar = () => {
           }}
         >
           <Box>{action}</Box>
-          <Collapse
-            in={expanded}
-            timeout="auto"
-            style={{ margin: "0 0 10px 0" }}
-            unmountOnExit
-          >
-            <Box sx={{ mt: 2 }}>
-              <p style={{ margin: "0 0 20px 0", fontWeight: "800" }}>
-                What brought you to Food Oasis today?
-              </p>
-              <div onClick={openForm} style={{ cursor: "pointer" }}>
-                <label style={labelStyles}>
-                  <input
-                    style={inputStyles}
-                    type="checkbox"
-                    name="option"
-                    value="myself"
-                  />
-                  Looking for myself
-                </label>
-                <label style={labelStyles}>
-                  <input
-                    style={inputStyles}
-                    type="checkbox"
-                    name="option"
-                    value="friend-family"
-                  />
-                  Looking for a friend/family member
-                </label>
-                <label style={labelStyles}>
-                  <input
-                    style={inputStyles}
-                    type="checkbox"
-                    name="option"
-                    value="social-worker"
-                  />
-                  I'm a social worker looking for a client
-                </label>
-                <label style={labelStyles}>
-                  <input
-                    style={inputStyles}
-                    type="checkbox"
-                    name="option"
-                    value="volunteer"
-                  />
-                  Food Oasis volunteer
-                </label>
-                <label style={labelStyles}>
-                  <input
-                    style={inputStyles}
-                    type="checkbox"
-                    name="option"
-                    value="other"
-                  />
-                  Other
-                </label>
-              </div>
-
-              <div
-                className="survey-buttons"
-                style={{
-                  display: "flex",
-                  justifyContent: "space-evenly",
-                  margin: "30px 0 0 0",
-                }}
-              >
-                <Button onClick={openForm}> Complete Survey </Button>
-                <Button onClick={handleClose}> Close </Button>
-              </div>
-            </Box>
-          </Collapse>
         </Box>
       </Snackbar>
     </Stack>


### PR DESCRIPTION
Closes #2165 

- [x] Used Local Storage so that it wont pop up again if a user clicks "close"

- [x] Expands and Collapses

- [x] When you click it it opens the form in a new page  
https://docs.google.com/forms/d/e/1FAIpQLSdAhi_nMKQfWVHjfpl1ZkmymBTt8BW7YNqVIOJ4JKYgSL4O3g/viewform

- [x] Should be rendered at the bottom right of the page


<img width="458" alt="Screenshot 2024-08-17 at 4 02 57 PM" src="https://github.com/user-attachments/assets/6de34c43-26cd-44e3-af2b-172165355298">

<img width="468" alt="Screenshot 2024-08-17 at 4 03 05 PM" src="https://github.com/user-attachments/assets/07876247-ae13-4a32-b791-56b7bba07572">

<img width="704" alt="Screenshot 2024-08-17 at 4 03 21 PM" src="https://github.com/user-attachments/assets/c5642c7c-c341-493d-abcb-03514cf6512e">

What it looks like when its closed
<img width="393" alt="Screenshot 2024-08-17 at 4 03 34 PM" src="https://github.com/user-attachments/assets/9a0fae07-1a27-4b2a-9705-48fe52f8500a">


Grand-parent issue: 
- #1769