### PR TITLE
Add client-side validation, tooltip, go to link and design for Facebook And Instagram contact field 

### DIFF
--- a/client/src/components/Admin/OrganizationEdit.js
+++ b/client/src/components/Admin/OrganizationEdit.js
@@ -51,6 +51,13 @@ const validationSchema = Yup.object().shape({
   longitude: Yup.number().required("Longitude is required").min(-180).max(180),
   email: Yup.string().email("Invalid email address format"),
   hours: Yup.array().of(HourSchema),
+  instagram: Yup.string()
+    .transform((value, originalValue) => (originalValue === "" ? null : value))
+    .matches(
+      /^(?:@?[a-zA-Z0-9_.]{1,30})$/,
+      "Valid Instagram username required."
+    )
+    .nullable(),
   twitter: Yup.string()
     .transform((value, originalValue) => (originalValue === "" ? null : value))
     .matches(/^(?:@?[a-zA-Z0-9_]{1,15})$/, "Valid Twitter username required.")
@@ -63,6 +70,12 @@ const validationSchema = Yup.object().shape({
     .matches(
       /^@?(?=.*[a-zA-Z])[a-zA-Z0-9_]{3,30}$/,
       "Valid Pinterest username is required."
+    )
+    .nullable(),
+  facebook: Yup.string()
+    .matches(
+      /^[a-zA-Z][a-zA-Z0-9.]{4,49}$/,
+      "Valid Facebook username required."
     )
     .nullable(),
 

--- a/client/src/components/Admin/OrganizationEdit/ContactDetails.js
+++ b/client/src/components/Admin/OrganizationEdit/ContactDetails.js
@@ -117,7 +117,7 @@ export default function ContactDetails({
             <CustomTextFieldComponent
               id="facebook"
               name="facebook"
-              placeholder="Facebook handle"
+              placeholder="Facebook username"
               value={values.facebook}
               onChange={handleChange}
               onBlur={handleBlur}

--- a/client/src/components/Admin/OrganizationEdit/ContactDetails.js
+++ b/client/src/components/Admin/OrganizationEdit/ContactDetails.js
@@ -85,31 +85,45 @@ export default function ContactDetails({
         </Grid>
         <Grid item sm={6} xs={12}>
           <div>
-            <Label id="instagram" label="Instagram" />
-            <TextField
+            <Label
+              id="instagram"
+              label="Instagram"
+              tooltipTitle="Enter your Instagram username"
+              href="https://instagram.com/"
+              handle={values.instagram}
+            />
+            <CustomTextFieldComponent
               id="instagram"
               name="instagram"
-              placeholder="Instagram"
+              placeholder="Instagram username"
               value={values.instagram}
               onChange={handleChange}
               onBlur={handleBlur}
-              helperText={touched.instagram ? errors.instagram : ""}
-              error={touched.instagram && Boolean(errors.instagram)}
+              touched={touched.instagram}
+              errors={errors.instagram}
+              startAdornment="https://instagram.com/"
             />
           </div>
         </Grid>
         <Grid item sm={6} xs={12}>
           <div>
-            <Label id="facebook" label="Facebook" />
-            <TextField
+            <Label
+              id="facebook"
+              label="Facebook"
+              tooltipTitle="Enter your Facebook username"
+              href="https://facebook.com/"
+              handle={values.facebook}
+            />
+            <CustomTextFieldComponent
               id="facebook"
               name="facebook"
-              placeholder="Facebook"
+              placeholder="Facebook handle"
               value={values.facebook}
               onChange={handleChange}
               onBlur={handleBlur}
-              helperText={touched.facebook ? errors.facebook : ""}
-              error={touched.facebook && Boolean(errors.facebook)}
+              touched={touched.facebook}
+              errors={errors.facebook}
+              startAdornment="https://facebook.com/"
             />
           </div>
         </Grid>
@@ -125,7 +139,7 @@ export default function ContactDetails({
             <CustomTextFieldComponent
               id="twitter"
               name="twitter"
-              placeholder="Twitter handle"
+              placeholder="Twitter username"
               value={values.twitter}
               onChange={handleChange}
               onBlur={handleBlur}


### PR DESCRIPTION
Closes #2202 & #2201 

Completed List
- [x] add design to the contact field
- [x] add tooltip
- [x] add go to link when user enters text into the field
- [x] add validation to the field

**FACEBOOK** 

**BEFORE:**

![Screenshot 2024-09-06 at 2 11 57 PM](https://github.com/user-attachments/assets/a9aa7b81-227b-426d-a0c1-30aa3b995820)

**AFTER:**

![Screenshot 2024-09-06 at 3 17 22 PM](https://github.com/user-attachments/assets/1c87f823-d1d6-44ad-9c5e-b05f458e1369)

**INSTAGRAM**

**BEFORE:**

![Screenshot 2024-09-06 at 1 01 46 PM](https://github.com/user-attachments/assets/15cbf0f1-8897-427c-b108-bcf05e89ac8d)


**AFTER:**
![Screenshot 2024-09-06 at 3 32 46 PM](https://github.com/user-attachments/assets/6495a88f-d4cb-4804-8a3d-2f767f209be7)


**ALL TOGETHER:**
![Screenshot 2024-09-06 at 3 33 40 PM](https://github.com/user-attachments/assets/1e2c34fe-4469-40d5-9f1d-9277b1652724)


