### PR TITLE
2190 change css for organization name links to be more obvious

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.js
@@ -200,8 +200,7 @@ const StakeholderPreview = ({ stakeholder, onSelect, isDesktop }) => {
               align="left"
               fontWeight="bold"
               sx={{
-                color: { xs: "black", md: "inherit" },
-                textDecoration: { xs: "underline", md: "none" },
+                textDecoration: "underline",
               }}
               onClick={() => handleSelectOrganization(stakeholder)}
             >


### PR DESCRIPTION
Closes #2190 

added underline to title, to make it look more clickable as requested
![Screenshot 2024-09-10 at 5 57 06 PM](https://github.com/user-attachments/assets/6d050bd8-4cda-43a3-b1d9-6cf2ac6867a5)
![after](https://github.com/user-attachments/assets/2b2e6822-9f08-4c1b-b6d3-a1eef1529977)
