### PR TITLE
Adding settimeout to enable slower zip code typing

### DIFF
--- a/client/src/components/FoodSeeker/AddressDropDown.js
+++ b/client/src/components/FoodSeeker/AddressDropDown.js
@@ -31,7 +31,9 @@ export default function AddressDropDown({ autoFocus }) {
   const handleInputChange = (delta) => {
     if (!delta) return;
     const safeValue = typeof delta === "string" ? delta : delta.target.value;
-    setInputVal(safeValue);
+    setTimeout(() => {
+      setInputVal(safeValue);
+    }, 100);
     if (safeValue) {
       fetchMapboxResults(safeValue);
     }


### PR DESCRIPTION
- Closes #2186 
- Adding settimeout just makes sure that the user is not able to type the zip code too fast (and so the zipcode resolves correctly). Please let me know if this might not be an acceptable solution and I can look for some other way to fix this.