### PR TITLE
changed geocoder autocomplete to false

### DIFF
--- a/client/src/hooks/useMapboxGeocoder.js
+++ b/client/src/hooks/useMapboxGeocoder.js
@@ -57,7 +57,7 @@ export function useMapboxGeocoder() {
           : tenantId === 3
           ? hawaiiLatLong
           : losAngelesCountyLatLong;
-      const mapboxUrl = `${baseUrl}/${searchString}.json?bbox=${bbox}&access_token=${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`;
+      const mapboxUrl = `${baseUrl}/${searchString}.json?bbox=${bbox}&autocomplete=false&access_token=${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`;
 
       dispatch({ type: actionTypes.FETCH_REQUEST });
       try {


### PR DESCRIPTION
- Fixes #2186 
- autocomplete prompts only appear if there is an exact match.
- hitting the return key really fast still breaks the search, not getting 90045 instead of 90015 though.


https://github.com/user-attachments/assets/ec2b2c20-b73a-437f-b63b-567cd3222d0b

