### PR TITLE
Fixed error with typing zipcode fast in search bar

### DIFF
--- a/client/src/hooks/useMapboxGeocoder.js
+++ b/client/src/hooks/useMapboxGeocoder.js
@@ -70,7 +70,7 @@ export function useMapboxGeocoder() {
         dispatch({ type: actionTypes.FETCH_FAILURE, error });
       }
     },
-    { wait: 300 }
+    { wait: 300, after: false, before: true }
   );
 
   return { error, isLoading, mapboxResults, fetchMapboxResults };


### PR DESCRIPTION
Fixes #2186 

Changed the edge of the debouncer trigger to before the wait interval so the geocoder is called with the complete input text. 