### PR TITLE
button component for correct zoom #2299

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.jsx
@@ -13,7 +13,7 @@ import { MAPBOX_ACCESS_TOKEN, DEFAULT_VIEWPORT } from "helpers/Constants";
 import useBreakpoints from "hooks/useBreakpoints";
 import useFeatureFlag from "hooks/useFeatureFlag";
 import 'mapbox-gl/dist/mapbox-gl.css';
-import Map, { Layer, Marker, NavigationControl, Source } from "react-map-gl";
+import Map, { Layer, Marker, Source } from "react-map-gl";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as analytics from "services/analytics";
 import {
@@ -43,7 +43,7 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
   const selectedOrganization = useSelectedOrganization();
   const navigate = useNavigate();
   const location = useLocation();
-  const { isMobile } = useBreakpoints();
+  const { isMobile, isTablet } = useBreakpoints();
   const isListPanelOpen = useListPanel();
   const isFilterPanelOpen = useFilterPanel();
   const { mapRef, flyTo } = useMapbox();
@@ -146,7 +146,7 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
     const handleZoomIn = () => {
       const longOffset = 0.0399 * Math.pow(2, 11 - zoom);
       const newCenter = {
-        lng: currentCenter.lng + longOffset,
+        lng: !isTablet && isListPanelOpen ? currentCenter.lng + longOffset : currentCenter.lng,
         lat: selectedOrganization ? selectedOrganization.latitude : currentCenter.lat
       };
 

--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.jsx
@@ -7,7 +7,9 @@ import { useCallback, useEffect, useState } from "react";
 // recommendation from Mapbox team
 // https://github.com/mapbox/mapbox-gl-js/issues/10173  See comment by IvanDreamer on Mar 22
 // for craco.config.js contents
-import { Grid, Box } from "@mui/material";
+import { Grid, Box, IconButton } from "@mui/material";
+import AddIcon from '@mui/icons-material/AddRounded';
+import RemoveIcon from '@mui/icons-material/RemoveRounded';
 import { MAPBOX_STYLE } from "constants/map";
 import { MAPBOX_ACCESS_TOKEN, DEFAULT_VIEWPORT } from "helpers/Constants";
 import useBreakpoints from "hooks/useBreakpoints";
@@ -139,7 +141,6 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
 
   const CustomNavigationControl = () => {
     if (!currMap) return;
-
     const zoom = currMap.getZoom();
     const currentCenter = currMap.getCenter();
   
@@ -172,17 +173,11 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
     };
 
     const buttonStyles = {
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
+      color: "#313131",
+      borderBottom: "1px solid rgba(0, 0, 0, 0.1)",
+      borderRadius: 0,
       width: "28px",
       height: "28px",
-      fontSize: "16px",
-      fontWeight: 700,
-      color: "#313131",
-      cursor: "pointer",
-      userSelect: "none",
-      borderBottom: "1px solid rgba(0, 0, 0, 0.1)",
       '&:hover': {
         backgroundColor: "#f5f5f5",
       },
@@ -195,8 +190,8 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
       <Box
         sx={{
           position: "absolute",
-          top: 8,
-          right: 8,
+          top: 10,
+          right: 10,
           zIndex: 10,
           display: "flex",
           flexDirection: "column",
@@ -207,18 +202,12 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
           overflow: "hidden",
         }}
       >
-        <Box
-          onClick={handleZoomIn}
-          sx={buttonStyles}
-        >
-          ＋
-        </Box>
-        <Box
-          onClick={handleZoomOut}
-          sx={[buttonStyles, { fontSize: 14 }]}
-        >
-          ―
-        </Box>
+        <IconButton onClick={handleZoomIn} sx={buttonStyles} size="small">
+          <AddIcon />
+        </IconButton>
+        <IconButton onClick={handleZoomOut} sx={buttonStyles}>
+          <RemoveIcon />
+        </IconButton>
       </Box>
     );
 };


### PR DESCRIPTION
Closes #2299 

This is a custom button component replacing the default zoom buttons in Mapbox. Mapbox's default button behavior isn't customizable, so the buttons in this replacement component account for the fact that our map's marker's are on the right side in desktop view when the panel is open, and adjust accordingly. The mouse and trackpad scrolling is unaffected.