### PR TITLE
Geolocate button moved into map #1725

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/ResultsFilters.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/ResultsFilters.jsx
@@ -154,42 +154,6 @@ const ResultsFilters = ({
               }}
             >
               <AddressDropDown autoFocus={false} />
-              {/* THIS BUTTON ISN'T HERE IN THE NEW DESIGN FOR PHONE */}
-              <Tooltip
-                title={
-                  locationPermission === "denied" || !!error
-                    ? "Please allow location access"
-                    : "Show Your Current Location"
-                }
-              >
-                <Box
-                  sx={{
-                    display: { xs: "block", sm: "block" },
-                  }}
-                >
-                  <Button
-                    variant="recenter"
-                    onClick={useMyLocationTrigger}
-                    disabled={locationPermission === "denied" || !!error}
-                    icon="locationSearching"
-                    sx={(theme) => ({
-                      backgroundColor: theme.palette.common.white,
-                      "&:hover": {
-                        backgroundColor: theme.palette.common.white,
-                      },
-                    })}
-                  >
-                    <LocationSearching
-                      sx={(theme) => ({
-                        fontSize: "1.25rem",
-                        backgroundColor: theme.palette.common.white,
-                        color: theme.palette.common.black,
-                      })}
-                    />
-                  </Button>
-                </Box>
-              </Tooltip>
-              {/* =================================================== */}
               <Box
                 sx={{
                   maxWidth: "48px",

--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.jsx
@@ -8,14 +8,14 @@ import { useCallback, useEffect, useState } from "react";
 // https://github.com/mapbox/mapbox-gl-js/issues/10173  See comment by IvanDreamer on Mar 22
 // for craco.config.js contents
 import { Grid, Box, IconButton } from "@mui/material";
-import AddIcon from '@mui/icons-material/AddRounded';
-import RemoveIcon from '@mui/icons-material/RemoveRounded';
+import AddIcon from "@mui/icons-material/AddRounded";
+import RemoveIcon from "@mui/icons-material/RemoveRounded";
 import { MAPBOX_STYLE } from "constants/map";
 import { MAPBOX_ACCESS_TOKEN, DEFAULT_VIEWPORT } from "helpers/Constants";
 import useBreakpoints from "hooks/useBreakpoints";
 import useFeatureFlag from "hooks/useFeatureFlag";
-import 'mapbox-gl/dist/mapbox-gl.css';
-import Map, { Layer, Marker, Source } from "react-map-gl";
+import "mapbox-gl/dist/mapbox-gl.css";
+import Map, { GeolocateControl, Layer, Marker, Source } from "react-map-gl";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as analytics from "services/analytics";
 import {
@@ -87,7 +87,6 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
     }));
   }, [searchCoordinates, longitude, latitude, isMobile]);
 
-
   const onLoad = useCallback(async () => {
     const map = mapRef.current.getMap();
     setCurrMap(map);
@@ -143,33 +142,38 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
     if (!currMap) return;
     const zoom = currMap.getZoom();
     const currentCenter = currMap.getCenter();
-  
+
     const handleZoomIn = () => {
       const longOffset = 0.0399 * Math.pow(2, 11 - zoom);
       const newCenter = {
-        lng: !isTablet && isListPanelOpen ? currentCenter.lng + longOffset : currentCenter.lng,
-        lat: selectedOrganization ? selectedOrganization.latitude : currentCenter.lat
+        lng:
+          !isTablet && isListPanelOpen
+            ? currentCenter.lng + longOffset
+            : currentCenter.lng,
+        lat: selectedOrganization
+          ? selectedOrganization.latitude
+          : currentCenter.lat,
       };
 
       currMap.easeTo({
         center: isListPanelOpen ? newCenter : currentCenter,
         zoom: zoom + 1,
         duration: 500,
-      })
+      });
     };
-  
+
     const handleZoomOut = () => {
       const zoomOutOffset = 0.0399 * Math.pow(2, 12 - zoom);
       const newCenter = {
         lng: currentCenter.lng - zoomOutOffset,
-        lat: currentCenter.lat
+        lat: currentCenter.lat,
       };
-      
+
       currMap.easeTo({
         center: isListPanelOpen ? newCenter : currentCenter,
         zoom: zoom - 1,
         duration: 500,
-      })
+      });
     };
 
     const buttonStyles = {
@@ -178,14 +182,14 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
       borderRadius: 0,
       width: "28px",
       height: "28px",
-      '&:hover': {
+      "&:hover": {
         backgroundColor: "#f5f5f5",
       },
-      '&:active': {
+      "&:active": {
         backgroundColor: "#e0e0e0",
       },
     };
-  
+
     return (
       <Box
         sx={{
@@ -210,7 +214,7 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
         </IconButton>
       </Box>
     );
-};
+  };
 
   return (
     <div style={{ position: "relative", height: "100%", width: "100%" }}>
@@ -229,9 +233,13 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        {!isMobile && (
-          <CustomNavigationControl />
-        )}
+        {!isMobile && <CustomNavigationControl />}
+        <GeolocateControl
+          positionOptions={{ enableHighAccuracy: true }}
+          trackUserLocation={false}
+          showUserHeading={true}
+          position="bottom-right"
+        />
         {startIconCoordinates && (
           <Marker
             longitude={startIconCoordinates.longitude}
@@ -263,20 +271,24 @@ const ResultsMap = ({ stakeholders, categoryIds, toggleCategory, loading }) => {
           display="inline-flex"
           alignItems="flex-start"
           sx={{
-            overflowX: "auto", 
-            overflowY: "hidden", 
+            overflowX: "auto",
+            overflowY: "hidden",
             gap: "0.5rem",
             padding: isMobile ? "0 0 0.3rem 0.75rem" : "0 0 0.3rem 2.25rem",
             scrollbarWidth: "none",
             "&::-webkit-scrollbar": {
-              display: "none", 
+              display: "none",
             },
             top: 0,
             left: isMobile
               ? 0
               : `${listPanelLeftPostion + filterPanelLeftPostion}px`,
             transition: isMobile ? undefined : "left .5s ease-in-out",
-            maxWidth: isMobile ? "100vw": `calc(100vw - ${listPanelLeftPostion + filterPanelLeftPostion}px)`,
+            maxWidth: isMobile
+              ? "100vw"
+              : `calc(100vw - ${
+                  listPanelLeftPostion + filterPanelLeftPostion
+                }px)`,
           }}
         >
           <AdvancedFilters


### PR DESCRIPTION
Resolves #1725 

This fix uses Mapbox's GeolocateControl component to handle the geolocate functionality and will reflect the user's browser location preferences (if set). It removed the need for the button next to the address above the map.