### PR TITLE
hover and selected color update

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/AdvancedFilters/AdvancedFilterButton.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/AdvancedFilters/AdvancedFilterButton.jsx
@@ -36,7 +36,9 @@ const CustomButton = styled(Button, {
       ? theme.palette.filterButtons.backgroundColor
       : theme.palette.common.white,
     "&:hover": {
-      backgroundColor: theme.palette.filterButtons.backgroundColor,
+      backgroundColor: isSelected
+        ? theme.palette.filterButtons.hoverSelectedColor
+        : theme.palette.filterButtons.hoverColor,
     },
   },
 }));

--- a/client/src/theme/palette.tsx
+++ b/client/src/theme/palette.tsx
@@ -85,6 +85,7 @@ export const palette = {
     },
     backgroundColor: "#E6F0FF",
     bodyText: "#313233",
-    hoverColor: "#CBE3F1",
+    hoverColor: "#f0f0f0",
+    hoverSelectedColor: "#D9E3F2"
   },
 };


### PR DESCRIPTION
Resolves #2267 

Filter button hover and selected colors are updated to eliminate confusion. The hover color is gray while the selected color is the original blue. This color now changes to a darker blue one when an already selected button is hovered over. 