### PR TITLE
Fix the react warning on the address dropdown

### DIFF
--- a/client/src/components/FoodSeeker/AddressDropDown.jsx
+++ b/client/src/components/FoodSeeker/AddressDropDown.jsx
@@ -107,9 +107,11 @@ export default function AddressDropDown({ autoFocus }) {
   };
 
   const renderOption = (props, option) => {
+    const { key } = props;
     return (
       <MenuItem
         {...props}
+        key={key}
         component="div"
         onClick={() => handleAutocompleteOnChange(option)}
       >


### PR DESCRIPTION
We noticed this react warning 👀 

<img width="1709" alt="Screenshot 2025-04-06 at 3 25 39 PM" src="https://github.com/user-attachments/assets/3e038c12-bf90-4355-b6ba-d8f221a0d21a" />
