### PR TITLE
Verification Admin needs to show inactive categories

### DIFF
--- a/client/src/components/Admin/VerificationAdmin.jsx
+++ b/client/src/components/Admin/VerificationAdmin.jsx
@@ -365,7 +365,7 @@ function VerificationAdmin() {
                 userLongitude={
                   userCoordinates?.longitude || origin?.longitude || 0
                 }
-                categories={categories && categories.filter((c) => !c.inactive)}
+                categories={categories}
                 tags={tags}
                 neighborhoods={neighborhoods}
                 criteria={criteria}


### PR DESCRIPTION
Fixes Issue #2469 

Verification Admin Screen needs to be able to find listings with "inactive" categories.