### PR TITLE
clear search and fix flyTo bug

### DIFF
--- a/client/src/components/FoodSeeker/AddressDropDown.jsx
+++ b/client/src/components/FoodSeeker/AddressDropDown.jsx
@@ -6,18 +6,20 @@ import {
   TextField,
 } from "@mui/material";
 import { useMapboxGeocoder } from "hooks/useMapboxGeocoder";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as analytics from "services/analytics";
 import {
   useAppDispatch,
   useSearchCoordinates,
+  useUserCoordinates,
   useWidget,
 } from "../../appReducer";
 import { useMapbox } from "../../hooks/useMapbox";
 
 export default function AddressDropDown({ autoFocus }) {
   const searchCoordinates = useSearchCoordinates();
+  const userCoordinates = useUserCoordinates();
   const isWidget = useWidget();
   const [inputVal, setInputVal] = useState(
     searchCoordinates?.locationName || ""
@@ -28,6 +30,12 @@ export default function AddressDropDown({ autoFocus }) {
   const navigate = useNavigate();
   const { flyTo } = useMapbox();
   const [highlightedOption, setHighlightedOption] = useState(null);
+
+  useEffect(() => {
+    if (userCoordinates) {
+      setInputVal("");
+    }
+  }, [userCoordinates]);
 
   const handleInputChange = (delta) => {
     if (!delta) return;

--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/Geolocate.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/Geolocate.jsx
@@ -3,17 +3,12 @@ import { Button, Tooltip } from "@mui/material";
 import useGeolocation, { useLocationPermission } from "hooks/useGeolocation";
 import { useState, useEffect } from "react";
 import * as analytics from "services/analytics";
-import {
-  useSearchCoordinates,
-  useUserCoordinates,
-} from "../../../../appReducer";
+import { useUserCoordinates } from "../../../../appReducer";
 import { useMapbox } from "../../../../hooks/useMapbox";
 
 const Geolocate = () => {
   const { getUserLocation } = useGeolocation();
-  const searchCoordinates = useSearchCoordinates();
   const userCoordinates = useUserCoordinates();
-  const startIconCoordinates = searchCoordinates || userCoordinates;
   const locationPermission = useLocationPermission();
   const [error, setError] = useState("");
   const { flyTo } = useMapbox();
@@ -22,16 +17,17 @@ const Geolocate = () => {
     if (error && locationPermission === "granted") {
       setError("");
     }
-  }, [error, locationPermission]);
+    if (locationPermission === "granted" && userCoordinates) {
+      flyTo({
+        longitude: userCoordinates.longitude,
+        latitude: userCoordinates.latitude,
+      });
+    }
+  }, [error, locationPermission, userCoordinates]);
 
   const useMyLocationTrigger = async () => {
     try {
       await getUserLocation();
-      startIconCoordinates &&
-        flyTo({
-          longitude: startIconCoordinates.longitude,
-          latitude: searchCoordinates.latitude,
-        });
     } catch (e) {
       setError(e);
     }


### PR DESCRIPTION
Resolves #2261 

- Clears the previous search text (if any)from the AddressDropdown when the user updates their location with the Geolocate button
- Fixes the bug where flyTo didn't center the user's location until the geolocate button was pressed twice