### PR TITLE
fix-show SurveySnackbar only on user-facing routes

### DIFF
--- a/client/src/Routes.jsx
+++ b/client/src/Routes.jsx
@@ -11,7 +11,6 @@ import { useWidget } from "./appReducer";
 import useFeatureFlag from "./hooks/useFeatureFlag";
 import SurveySnackbar from "./components/UI/SurveySnackbar";
 import AnnouncementSnackbar from "components/UI/AnnouncementSnackbar";
-import useLocationHook from "hooks/useLocationHook";
 
 const VerificationAdmin = lazy(() =>
   import("components/Admin/VerificationAdmin")

--- a/client/src/Routes.jsx
+++ b/client/src/Routes.jsx
@@ -55,8 +55,15 @@ const Profile = lazy(() => import("./components/Account/Profile"));
 const Suggestion = lazy(() => import("components/FoodSeeker/Suggestion"));
 
 export default function AppRoutes() {
-  const hasUserFeedbackSuveyFeatureFlag = useFeatureFlag("userFeedbackSurvey");
   const location = useLocation();
+  const pathname = location.pathname;
+  const hasUserFeedbackSuveyFeatureFlag = useFeatureFlag("userFeedbackSurvey");
+  const isAdminRoute = pathname.startsWith("/admin");
+  const isWidgetRoute = pathname === "/widget";
+  const isUserFacingRoute = !isAdminRoute && !isWidgetRoute;
+
+  const showSurveySnackbar =
+    hasUserFeedbackSuveyFeatureFlag && isUserFacingRoute;
 
   return (
     <Suspense
@@ -66,9 +73,7 @@ export default function AppRoutes() {
         </Stack>
       }
     >
-      {hasUserFeedbackSuveyFeatureFlag && location.pathname !== "/widget" && (
-        <SurveySnackbar />
-      )}
+      {showSurveySnackbar && <SurveySnackbar />}
 
       <Routes>
         <Route path="/" element={<AppWrapper />}>

--- a/client/tests/helpers/mocks.ts
+++ b/client/tests/helpers/mocks.ts
@@ -7,7 +7,7 @@ export default async function mockRequests(
   const mocks = {
     ...MOCKS,
     ...overrides,
-  }
+  };
 
   Object.entries(mocks).forEach(([path, response]) => {
     const handler = typeof response === "function" ? response : () => response;
@@ -21,7 +21,7 @@ export default async function mockRequests(
         body: JSON.stringify(mockResponse),
       });
     });
-  })
+  });
 }
 
 const MOCKS = {
@@ -48,6 +48,7 @@ const MOCKS = {
       name: "advancedFilter",
       is_enabled: true,
     },
+    { id: 2, name: "userFeedbackSurvey", is_enabled: true },
   ],
   "stakeholderbests/select-all": makeStakeholdersResponse(),
 };
@@ -71,7 +72,7 @@ function makeLoginResponse() {
       isSecurityAdmin: false,
       isDataEntry: true,
       isCoordinator: false,
-      features: ["advancedFilter"],
+      features: ["advancedFilter", "userFeedbackSurvey"],
       role: "admin,data_entry,global_admin",
     },
   };

--- a/client/tests/surveySnackbarRouting.spec.ts
+++ b/client/tests/surveySnackbarRouting.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from "@playwright/test";
+import test from "./helpers/test";
+import mockRequests from "./helpers/mocks";
+
+// test("survey only shows on user facing routes and not within admin routes", async ({
+//   page,
+//   helpers,
+// }) => {
+//   await page.addInitScript(() => {
+//     localStorage.setItem(
+//       "featureFlags",
+//       JSON.stringify({ userFeedbackSurvey: true })
+//     );
+//   });
+
+//   await mockRequests(page);
+//   await page.goto("/");
+
+//   const survey = page
+//     .getByRole("alert")
+//     .filter({ hasText: /Help us improve!/i });
+//   await expect(survey).toBeVisible();
+//   await helpers.mockLogin();
+
+//   await expect(survey).toHaveCount(0);
+// });
+
+test("SurveySnackbar shows on user routes and hides on admin routes", async ({
+  page,
+  helpers,
+}) => {
+  await mockRequests(page);
+  await page.goto("/");
+  await expect(page.getByText("Help us improve!")).toBeVisible();
+  await helpers.mockLogin();
+  await expect(page).toHaveURL(/\/admin\//);
+  const surveyAfterLogin = page
+    .getByRole("alert")
+    .filter({ hasText: /help us improve!/i });
+  await expect(surveyAfterLogin).toHaveCount(0);
+});


### PR DESCRIPTION
fix #2460 
Before:
![image](https://github.com/user-attachments/assets/cc95460f-5e02-4ac5-8b5f-db1021d39621)

After: 
![image](https://github.com/user-attachments/assets/cef0e2d9-c039-4b8c-9306-93bce8a620ec)

