### PR TITLE
Remove word covid from admin table

### DIFF
--- a/client/src/components/Admin/OrganizationEdit/Identification.jsx
+++ b/client/src/components/Admin/OrganizationEdit/Identification.jsx
@@ -371,7 +371,7 @@ export default function Identification({
                   onBlur={handleBlur}
                 />
               }
-              label="Temporarily Closed (COVID)"
+              label="Temporarily Closed"
             />
           </Tooltip>
         </Grid>
@@ -379,13 +379,13 @@ export default function Identification({
           <div>
             <Label
               id="covidNotes"
-              label="COVID Notes"
-              tooltipTitle="COVID-related conditions"
+              label="Closure Notes"
+              tooltipTitle="Add details about closures or service changes"
             />
             <Textarea
               id="covidNotes"
               name="covidNotes"
-              placeholder="COVID Notes"
+              placeholder="Closure Notes"
               value={values.covidNotes}
               onChange={handleChange}
               onBlur={handleBlur}

--- a/client/src/components/Admin/SearchCriteria.jsx
+++ b/client/src/components/Admin/SearchCriteria.jsx
@@ -244,7 +244,7 @@ const SearchCriteria = ({
           </Grid>
           <Grid item xs={12} sm={4}>
             <RadioTrueFalseEither
-              label="Closed for COVID"
+              label="Temporarily Closed"
               name="isInactiveTemporary"
               value={criteria.isInactiveTemporary || "either"}
               onChange={setCriterion}

--- a/client/src/components/Admin/SearchCriteriaDisplay.jsx
+++ b/client/src/components/Admin/SearchCriteriaDisplay.jsx
@@ -299,7 +299,7 @@ function SearchCriteriaDisplay({
           key={"CriteriaChip_ClosedForCOVID"}
           name="isInactiveTemporary"
           value={inactiveTemporaryLabel}
-          label="Closed for COVID"
+          label="Temporarily Closed"
         />
       );
     }

--- a/client/src/components/Admin/VerificationAdminGridMui.jsx
+++ b/client/src/components/Admin/VerificationAdminGridMui.jsx
@@ -112,7 +112,7 @@ const adminColumns = [
   },
   {
     field: "inactiveTemporary",
-    headerName: "Covid Closed",
+    headerName: "Temp Closed",
     renderCell: inactiveFormatter("inactiveTemporary"),
     width: 150,
   },
@@ -275,7 +275,7 @@ const dataEntryColumns = [
   },
   {
     field: "inactiveTemporary",
-    headerName: "Covid Closed",
+    headerName: "Temp Closed",
     renderCell: inactiveFormatter("inactiveTemporary"),
     width: 150,
   },

--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
@@ -651,7 +651,7 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
                   <DetailText>No notes to display.</DetailText>
                 )}
 
-                <MinorHeading>COVID Notes</MinorHeading>
+                <MinorHeading>Clousure Notes</MinorHeading>
                 {selectedOrganization.covidNotes ? (
                   <DetailText
                     dangerouslySetInnerHTML={{
@@ -659,7 +659,7 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
                     }}
                   ></DetailText>
                 ) : (
-                  <DetailText>No covid notes to display.</DetailText>
+                  <DetailText>No notes to display.</DetailText>
                 )}
 
                 {selectedOrganization.hoursNotes && (


### PR DESCRIPTION
closes #2447 
closes #2331 

- [x] ￼￼Change "Temporarily Closed (COVID)" field to "Temporarily Closed"
- [x] Change "Covid Notes" text field to "Closure notes"
- [x] Change "Covid Closed" column to "Temp. Closed"
- [x] Change search dialog's "Closed for Covid" to "Temporarily Closed"
- [x] Change stakeholder detail "Covid Notes" to "Closure notes"

<img width="1169" height="532" alt="image" src="https://github.com/user-attachments/assets/53ce5c98-a11f-46d4-83b5-40582191f512" />
<img width="1156" height="800" alt="image" src="https://github.com/user-attachments/assets/8e9f411f-45d1-472c-abe4-6875dc60fd09" />
<img width="1065" height="802" alt="image" src="https://github.com/user-attachments/assets/cf96e265-60a4-48c4-b6c2-6f74dc4f8645" />
<img width="458" height="733" alt="image" src="https://github.com/user-attachments/assets/a19fc0e4-344e-4ed0-ba29-f9b67c9c3f83" />

