### PR TITLE
feat filter panel custom hour any

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/FilterPanel.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/FilterPanel.jsx
@@ -345,6 +345,7 @@ const OPEN_TIME_DROPDOWNS = {
   time: {
     placeholder: "Open Time",
     labels: [
+      "Any",
       "12:00AM",
       "01:00AM",
       "02:00AM",

--- a/client/src/helpers/index.js
+++ b/client/src/helpers/index.js
@@ -218,10 +218,10 @@ export const computeDistances = (userLatitude, userLongitude, stakeholders) => {
  * Example output: "2023-12-24T06:00:00.003Z"
  */
 export const getNextDateForDay = (dayInput, timeInput, targetTimezone) => {
-  if (timeInput === "Any") {
-    const dayMap = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 };
-    const targetDay = dayMap[dayInput.toUpperCase()];
+  const dayMap = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 };
+  const targetDay = dayMap[dayInput.toUpperCase()];
 
+  if (timeInput === "Any") {
     let currentDate = dayjs().tz(targetTimezone);
     let currentDay = currentDate.day();
 
@@ -230,9 +230,6 @@ export const getNextDateForDay = (dayInput, timeInput, targetTimezone) => {
 
     return currentDate.add(dayDifference, "day").startOf("day");
   }
-
-  const dayMap = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 };
-  const targetDay = dayMap[dayInput.toUpperCase()];
 
   let time = dayjs(timeInput, "hh:mmA");
   let currentDate = dayjs().tz(targetTimezone);

--- a/client/src/helpers/index.js
+++ b/client/src/helpers/index.js
@@ -218,31 +218,37 @@ export const computeDistances = (userLatitude, userLongitude, stakeholders) => {
  * Example output: "2023-12-24T06:00:00.003Z"
  */
 export const getNextDateForDay = (dayInput, timeInput, targetTimezone) => {
+  if (timeInput === "Any") {
+    const dayMap = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 };
+    const targetDay = dayMap[dayInput.toUpperCase()];
+
+    let currentDate = dayjs().tz(targetTimezone);
+    let currentDay = currentDate.day();
+
+    let dayDifference = targetDay - currentDay;
+    if (dayDifference < 0) dayDifference += 7;
+
+    return currentDate.add(dayDifference, "day").startOf("day");
+  }
+
   const dayMap = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 };
   const targetDay = dayMap[dayInput.toUpperCase()];
 
-  // Parse the input time
   let time = dayjs(timeInput, "hh:mmA");
-
-  // Get the current date and time in the target timezone
   let currentDate = dayjs().tz(targetTimezone);
   let currentDay = currentDate.day();
 
-  // Calculate the difference in days
   let dayDifference = targetDay - currentDay;
   if (dayDifference < 0) dayDifference += 7;
   if (dayDifference === 0 && currentDate.hour() > time.hour()) {
     dayDifference += 7;
   }
 
-  // Set the target date and time
-  let targetDate = currentDate
+  return currentDate
     .add(dayDifference, "day")
     .set("hour", time.hour())
     .set("minute", time.minute())
     .set("second", 0);
-
-  return targetDate;
 };
 
 export const getDayTimeNow = () => {

--- a/client/src/hooks/useOrganizationBests.js
+++ b/client/src/hooks/useOrganizationBests.js
@@ -71,25 +71,44 @@ export default function useOrganizationBests() {
       }
 
       if (filters.showActiveOnly) {
-        // filter out inactive, inactiveTemporary stakeholders
         filteredStakeholders = filteredStakeholders.filter((stakeholder) => {
           return !stakeholder.inactive && !stakeholder.inactiveTemporary;
         });
       }
 
       const { day, time } = filters.openTimeFilter;
-      if (day !== "" && time !== "") {
+      if (day && time && time !== "Any") {
         filteredStakeholders = filteredStakeholders.filter((stakeholder) => {
           const nextDateForDay = getNextDateForDay(day, time, tenantTimeZone);
-          const hours = stakeholdersDaysHours(
+          return !!stakeholdersDaysHours(
             stakeholder,
             tenantTimeZone,
             nextDateForDay
           );
-
-          return !!hours;
+        });
+      } else if (day && (time === "" || time === "Any")) {
+        filteredStakeholders = filteredStakeholders.filter((stakeholder) => {
+          return stakeholder.hours?.some((h) =>
+            h.day_of_week.toUpperCase().startsWith(day.slice(0, 3))
+          );
+        });
+      } else if (!day && time && time !== "Any") {
+        filteredStakeholders = filteredStakeholders.filter((stakeholder) => {
+          return stakeholder.hours?.some((h) => {
+            const nextDateForDay = getNextDateForDay(
+              h.day_of_week,
+              time,
+              tenantTimeZone
+            );
+            return !!stakeholdersDaysHours(
+              stakeholder,
+              tenantTimeZone,
+              nextDateForDay
+            );
+          });
         });
       }
+
       if (filters.orgNameFilter) {
         filteredStakeholders = filteredStakeholders.filter((stakeholder) => {
           return filters.orgNameFilter


### PR DESCRIPTION
Closes #2385 

## WHAT
Open Time filter logic was updated to support more flexible custom day/time selections

* Day + Time → keeps existing behavior (filters by exact day and time).

* Day + Any → new filter logic, If user picks SUN + "Any", you’ll get all Sunday results.

* Time + Any day → new filter logic , If user don't pick a day + "11AM", you’ll get all results for 11AM

*  Both empty → shows all results (no filtering).

## What this PR Changed / Updated

Refactored useOrganizationBests filtering to handle four clear cases:

1. Day + Time
2. Day only (any time)
3. Time only (any day)
4. No filter

Replaced old "SUN" hack in time-only filtering with a check across all days.
Added "Any" to the time dropdown 

## Media

<img width="643" height="688" alt="Screenshot 2025-09-13 at 9 03 16 PM" src="https://github.com/user-attachments/assets/517e770c-e1d3-49df-8d7f-58937a80393c" />
<img width="640" height="684" alt="Screenshot 2025-09-13 at 9 03 54 PM" src="https://github.com/user-attachments/assets/832dc9b2-0709-4e64-82a4-5129f5bc6e35" />
<img width="641" height="642" alt="Screenshot 2025-09-13 at 9 05 01 PM" src="https://github.com/user-attachments/assets/6b73a9e4-3ac3-4c0b-a1cc-771c2f0e5c10" />

