### PR TITLE
Add warning indicator for listings older than 1 year

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
@@ -734,10 +734,12 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
                       selectedOrganization.modifiedDate,
                       selectedOrganization.createdDate
                     ) && (
-                      <Alert severity="warning">
-                        This information may be outdated <br />
-                        (last updated over 1 year ago)
-                      </Alert>
+                      <DetailText>
+                        <Alert severity="warning">
+                          This information may be outdated <br />
+                          (last updated over 1 year ago)
+                        </Alert>
+                      </DetailText>
                     )}
                     <DetailText>
                       Data updated on{" "}

--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   Chip,
@@ -244,6 +245,13 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
         console.error(e);
       }
     }
+  };
+
+  const isOldListing = (approvedDate, modifiedDate, createdDate) => {
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    const lastUpdated = approvedDate || modifiedDate || createdDate;
+    return lastUpdated && new Date(lastUpdated) < oneYearAgo;
   };
 
   const currentDate = new Date();
@@ -716,19 +724,30 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
                   >
                     sending a correction
                   </Link>
-                  .
                 </DetailText>
 
                 {selectedOrganization.verificationStatusId ===
                   VERIFICATION_STATUS.VERIFIED && (
-                  <DetailText>
-                    Data updated on{" "}
-                    {selectedOrganization.approvedDate
-                      ? formatDateMMMddYYYY(selectedOrganization.approvedDate)
-                      : selectedOrganization.modifiedDate
-                      ? formatDateMMMddYYYY(selectedOrganization.modifiedDate)
-                      : formatDateMMMddYYYY(selectedOrganization.createdDate)}
-                  </DetailText>
+                  <>
+                    {isOldListing(
+                      selectedOrganization.approvedDate,
+                      selectedOrganization.modifiedDate,
+                      selectedOrganization.createdDate
+                    ) && (
+                      <Alert severity="warning">
+                        This information may be outdated <br />
+                        (last updated over 1 year ago)
+                      </Alert>
+                    )}
+                    <DetailText>
+                      Data updated on{" "}
+                      {selectedOrganization.approvedDate
+                        ? formatDateMMMddYYYY(selectedOrganization.approvedDate)
+                        : selectedOrganization.modifiedDate
+                        ? formatDateMMMddYYYY(selectedOrganization.modifiedDate)
+                        : formatDateMMMddYYYY(selectedOrganization.createdDate)}
+                    </DetailText>
+                  </>
                 )}
               </Stack>
             </Stack>


### PR DESCRIPTION
Fixes #2068

## Summary
Adds a warning indicator for food assistance listings that haven't been updated in over 1 year, helping users identify potentially outdated information.

## Changes Made
- Added `isOldListing` function to check if listing dates are >1 year old
- Added warning message in `StakeholderDetails` component for old listings
- Used yellow warning from Material UI
- Warning appears above the "Data updated on" text for verified listings

## Media
<img width="524" height="914" alt="Screenshot 2025-09-15 at 4 43 47 PM" src="https://github.com/user-attachments/assets/d8bb1d11-36e0-495f-af03-e7acabc2a9f9" />
<img width="524" height="914" alt="Screenshot 2025-09-15 at 4 44 18 PM" src="https://github.com/user-attachments/assets/bea10d70-44d3-4d71-9075-00a8cb80b8b8" />
<img width="524" height="914" alt="Screenshot 2025-09-15 at 4 44 52 PM" src="https://github.com/user-attachments/assets/b4931a15-0649-436c-a6e9-a278593d148f" />
<img width="524" height="914" alt="Screenshot 2025-09-15 at 4 49 40 PM" src="https://github.com/user-attachments/assets/a30f811e-5efe-4996-84d8-4c9871d5a0a5" />

The screenshot shows three different styles available with Material UI.
I put the warning near the bottom with the date info since they're related. I tried moving it to the top (last screenshot) but didn't love how it looked. Happy to adjust the styling or position based on what the design team thinks works best.

