### PR TITLE
1273 add suggestions to stakeholder page

### DIFF
--- a/client/src/components/Admin/OrganizationEdit.jsx
+++ b/client/src/components/Admin/OrganizationEdit.jsx
@@ -889,7 +889,8 @@ const OrganizationEdit = (props) => {
                               handleSubmit();
                             }}
                             disabled={
-                              criticalFieldsValidate(values) ||
+                              isSubmitting ||
+                              Boolean(criticalFieldsValidate(values)) ||
                               values.verificationStatusId ===
                                 VERIFICATION_STATUS.NEEDS_VERIFICATION
                             }
@@ -922,6 +923,7 @@ const OrganizationEdit = (props) => {
                               handleSubmit();
                             }}
                             disabled={
+                              isSubmitting ||
                               !criticalFieldsValidate(values) ||
                               values.verificationStatusId ===
                                 VERIFICATION_STATUS.SUBMITTED

--- a/client/src/components/Admin/OrganizationEdit.jsx
+++ b/client/src/components/Admin/OrganizationEdit.jsx
@@ -24,6 +24,7 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import * as stakeholderService from "services/stakeholder-service";
+import * as suggestionService from "services/suggestion-service";
 import * as Yup from "yup";
 import BusinessHours from "./OrganizationEdit/BusinessHours";
 import ContactDetails from "./OrganizationEdit/ContactDetails";
@@ -42,6 +43,8 @@ import {
   DEFAULT_VIEWPORTS,
   TENANT_ID,
 } from "../../helpers/Constants";
+import { useSuggestionByStakeholderId } from "hooks/useSuggestionByStakeholderId";
+import SuggestionHistory from "./OrganizationEdit/SuggestionHistory";
 
 const phoneRegExp = /^\(\d{3}\) \d{3}-\d{4}$/;
 
@@ -220,6 +223,9 @@ const OrganizationEdit = (props) => {
   const { user } = useUserContext();
   const { setToast } = useToasterContext();
 
+  const { data: stakeholderSuggestions, refetch: refetchSuggestions } =
+    useSuggestionByStakeholderId(editId);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -394,6 +400,15 @@ const OrganizationEdit = (props) => {
     }
   };
 
+  const [editedSuggestions, setEditedSuggestions] = useState({});
+
+  const handleSuggestionEdit = (id, changes) => {
+    setEditedSuggestions((prev) => ({
+      ...prev,
+      [id]: { ...(prev[id] || {}), ...changes },
+    }));
+  };
+
   return (
     <Container component="main" maxWidth="lg">
       <div>
@@ -457,49 +472,43 @@ const OrganizationEdit = (props) => {
               }
             }
           }}
-          onSubmit={(values, { setSubmitting, setFieldValue }) => {
-            if (values.id) {
-              return stakeholderService
-                .put({ ...values, loginId: user.id })
-                .then(() => {
-                  setToast({
-                    message: "Update successful.",
-                  });
-                  setOriginalData(values);
-                  if (nextUrl) {
-                    navigate(nextUrl);
-                  }
-                })
+          onSubmit={async (values, { setSubmitting, setFieldValue }) => {
+            try {
+              if (values.id) {
+                await stakeholderService.put({ ...values, loginId: user.id });
+                setOriginalData(values);
+              } else {
+                const response = await stakeholderService.post({
+                  ...values,
+                  loginId: user.id,
+                });
+                setFieldValue("id", response.id);
+                setOriginalData({ ...values, id: response.id });
+              }
 
-                .catch((err) => {
-                  setToast({
-                    message:
-                      "Update failed. Please check for validation warnings on the Identification and Business Hours tabs and try again.",
-                  });
-                  console.error(err);
-                  setSubmitting(false);
-                });
-            } else {
-              return stakeholderService
-                .post({ ...values, loginId: user.id })
-                .then((response) => {
-                  setToast({
-                    message: "Insert successful.",
-                  });
-                  setFieldValue("id", response.id);
-                  setOriginalData({ ...values, id: response.id });
-                  if (nextUrl) {
-                    navigate(nextUrl);
-                  }
-                })
-                .catch((err) => {
-                  setToast({
-                    message:
-                      "Insert failed. Please check for validation warnings on the Identification and Business Hours tabs and try again.",
-                  });
-                  console.error(err);
-                  setSubmitting(false);
-                });
+              // Save changed suggestions
+              const suggestionUpdates = Object.entries(editedSuggestions).map(
+                ([id, changes]) =>
+                  suggestionService.update({ id: Number(id), ...changes })
+              );
+              await Promise.all(suggestionUpdates);
+              refetchSuggestions();
+
+              setToast({
+                message: `${values.id ? "Update" : "Insert"} successful.`,
+              });
+              setEditedSuggestions({});
+
+              if (nextUrl) navigate(nextUrl);
+            } catch (err) {
+              setToast({
+                message: `${
+                  values.id ? "Update" : "Insert"
+                } failed. Please check for validation warnings on the Identification and Business Hours tabs and try again.`,
+              });
+              console.error(err);
+            } finally {
+              setSubmitting(false);
             }
           }}
         >
@@ -515,6 +524,12 @@ const OrganizationEdit = (props) => {
             setFieldTouched,
           }) => (
             <form noValidate onSubmit={handleSubmit}>
+              <SuggestionHistory
+                suggestions={stakeholderSuggestions}
+                editedSuggestions={editedSuggestions}
+                onEdit={handleSuggestionEdit}
+                showNewOnly={true}
+              />
               <Stack direction="row" justifyContent="space-between">
                 <Typography component="h1" variant="h5">
                   {`Organization - ${values.name}`}
@@ -545,6 +560,7 @@ const OrganizationEdit = (props) => {
                       <Tab label="More Details" {...a11yProps(3)} />
                       <Tab label="Donations" {...a11yProps(4)} />
                       <Tab label="Verification" {...a11yProps(5)} />
+                      <Tab label="Suggestion History" {...a11yProps(6)} />
                     </Tabs>
                   </AppBar>
                   <Identification
@@ -601,6 +617,12 @@ const OrganizationEdit = (props) => {
                     setFieldValue={setFieldValue}
                     handleBlur={handleBlur}
                   />
+                  <SuggestionHistory
+                    tabPage={tabPage}
+                    suggestions={stakeholderSuggestions}
+                    editedSuggestions={editedSuggestions}
+                    onEdit={handleSuggestionEdit}
+                  />
                 </Box>
                 <Stack direction="row">
                   <div style={{ flexBasis: "20%", flexGrow: 1 }}>
@@ -635,7 +657,11 @@ const OrganizationEdit = (props) => {
                           <Button
                             variant="contained"
                             type="submit"
-                            disabled={isSubmitting || isUnchanged(values)}
+                            disabled={
+                              isSubmitting ||
+                              (isUnchanged(values) &&
+                                Object.keys(editedSuggestions).length === 0)
+                            }
                             sx={{
                               minHeight: "3.5rem",
                             }}
@@ -832,7 +858,11 @@ const OrganizationEdit = (props) => {
                               minHeight: "3.5rem",
                               display: "flex",
                             }}
-                            disabled={isSubmitting || isUnchanged(values)}
+                            disabled={
+                              isSubmitting ||
+                              (isUnchanged(values) &&
+                                Object.keys(editedSuggestions).length === 0)
+                            }
                           >
                             Save Progress
                           </Button>

--- a/client/src/components/Admin/OrganizationEdit/SuggestionHistory.jsx
+++ b/client/src/components/Admin/OrganizationEdit/SuggestionHistory.jsx
@@ -1,0 +1,142 @@
+import {
+  Box,
+  FormControlLabel,
+  InputLabel,
+  Paper,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import PropTypes from "prop-types";
+import { FILTERS } from "../Suggestions"; // reuse status options
+import { TabPanel } from "../ui/TabPanel";
+import Textarea from "../ui/Textarea";
+
+function formatDate(dateStr) {
+  if (!dateStr) return "";
+  return new Date(dateStr).toISOString().slice(0, 10);
+}
+
+export default function SuggestionHistory({
+  tabPage,
+  suggestions = [],
+  editedSuggestions,
+  onEdit,
+  showNewOnly = false,
+}) {
+  const handleInputChange = (id, field, value) => {
+    if (onEdit) onEdit(id, { [field]: value });
+  };
+  if (showNewOnly) {
+    suggestions = suggestions.filter(
+      (suggestion) => suggestion.suggestionStatusId === 1
+    );
+  }
+  if (showNewOnly && suggestions.length === 0) return null;
+
+  return (
+    <TabPanel value={tabPage} index={showNewOnly ? undefined : 6}>
+      <Stack spacing={3}>
+        {suggestions.map((suggestion) => (
+          <Paper
+            key={suggestion.id}
+            sx={(theme) => ({
+              backgroundColor: theme.palette.primary.extralight,
+              px: 4,
+              py: 2,
+            })}
+          >
+            <Typography variant="subtitle1" gutterBottom>
+              Suggestion ({formatDate(suggestion.createdDate)}
+              {suggestion.tipsterName && <> | {suggestion.tipsterName}</>}
+              {suggestion.tipsterEmail && <> | {suggestion.tipsterEmail}</>}
+              {suggestion.tipsterPhone && <> | {suggestion.tipsterPhone}</>})
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 1 }}>
+              {suggestion.notes}
+            </Typography>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={2}
+              alignItems="center"
+            >
+              <Stack
+                direction={"row"}
+                spacing={2}
+                sx={{ mb: 1, width: "100%" }}
+                flex={1}
+              >
+                <InputLabel
+                  htmlFor={`suggestionAdminNotes-${suggestion.id}`}
+                  sx={{ minWidth: "fit-content" }}
+                >
+                  Note:
+                </InputLabel>
+                <Textarea
+                  placeholder="Admin Notes"
+                  id={`suggestionAdminNotes-${suggestion.id}`}
+                  multiline
+                  fullWidth
+                  value={
+                    editedSuggestions[suggestion.id]?.adminNotes ??
+                    suggestion.adminNotes ??
+                    ""
+                  }
+                  onChange={(e) =>
+                    handleInputChange(
+                      suggestion.id,
+                      "adminNotes",
+                      e.target.value
+                    )
+                  }
+                />
+              </Stack>
+              <Box sx={{ minWidth: 200 }}>
+                <RadioGroup
+                  value={
+                    editedSuggestions[suggestion.id]?.suggestionStatusId ??
+                    suggestion.suggestionStatusId ??
+                    ""
+                  }
+                  onChange={(e) =>
+                    handleInputChange(
+                      suggestion.id,
+                      "suggestionStatusId",
+                      Number(e.target.value)
+                    )
+                  }
+                >
+                  {FILTERS.map((status) => (
+                    <FormControlLabel
+                      key={status.id}
+                      value={status.id}
+                      control={
+                        <Radio
+                          sx={(theme) => ({
+                            "&.Mui-checked": {
+                              color: theme.palette.secondary.main,
+                            },
+                          })}
+                        />
+                      }
+                      label={status.name}
+                    />
+                  ))}
+                </RadioGroup>
+              </Box>
+            </Stack>
+          </Paper>
+        ))}
+        {suggestions.length === 0 && (
+          <Typography>No suggestions found.</Typography>
+        )}
+      </Stack>
+    </TabPanel>
+  );
+}
+
+SuggestionHistory.propTypes = {
+  suggestions: PropTypes.array,
+  onEdit: PropTypes.func,
+};

--- a/client/src/components/Admin/Suggestions.jsx
+++ b/client/src/components/Admin/Suggestions.jsx
@@ -50,7 +50,7 @@ const columns = [
   { id: "formType", label: "Type", minWidth: 10 },
 ];
 
-const FILTERS = [
+export const FILTERS = [
   { id: 1, name: "New" },
   { id: 2, name: "Pending" },
   { id: 3, name: "Incorrect" },

--- a/client/src/hooks/useSuggestionByStakeholderId.js
+++ b/client/src/hooks/useSuggestionByStakeholderId.js
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+import * as suggestionService from "../services/suggestion-service";
+
+export const useSuggestionByStakeholderId = (stakeholderId) => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetch = useCallback(async () => {
+    const fetchApi = async () => {
+      if (!stakeholderId) return;
+
+      setLoading({ loading: true });
+      try {
+        const suggestions = await suggestionService.getByStakeholderId(
+          stakeholderId
+        );
+
+        setData(suggestions);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        console.error(err);
+      }
+    };
+    fetchApi();
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, error, loading, refetch: fetch };
+};

--- a/client/src/services/suggestion-service.js
+++ b/client/src/services/suggestion-service.js
@@ -17,6 +17,11 @@ export const getById = async (id) => {
   return response.data;
 };
 
+export const getByStakeholderId = async (id) => {
+  const response = await axios.get(`${baseUrl}/stakeholder/${id}`);
+  return response.data;
+};
+
 export const post = async (suggestion) => {
   const response = await axios.post(baseUrl, {
     ...suggestion,

--- a/server/app/controllers/suggestion-controller.ts
+++ b/server/app/controllers/suggestion-controller.ts
@@ -40,6 +40,25 @@ const getById: RequestHandler<{ id: string }, Suggestion, never> = async (
   }
 };
 
+const getByStakeholderId: RequestHandler<
+  { id: string },
+  Suggestion[],
+  never
+> = async (req, res) => {
+  try {
+    const id = req.params.id;
+    const resp = await suggestionService.selectByStakeholderId(id);
+    res.send(resp);
+  } catch (err: any) {
+    if (err.code === 0) {
+      res.sendStatus(404);
+    } else {
+      console.error(err);
+      res.sendStatus(500);
+    }
+  }
+};
+
 const post: RequestHandler<
   never,
   { id: number } | { error: string },
@@ -88,6 +107,7 @@ const remove: RequestHandler<{ id: string }, Response, never, never> = async (
 export default {
   getAll,
   getById,
+  getByStakeholderId,
   post,
   put,
   remove,

--- a/server/app/routes/suggestion-router.ts
+++ b/server/app/routes/suggestion-router.ts
@@ -10,6 +10,7 @@ import { requestValidationMiddleware } from "../../middleware/request-validation
 
 router.get("/", suggestionController.getAll);
 router.get("/:id", suggestionController.getById);
+router.get("/stakeholder/:id", suggestionController.getByStakeholderId);
 router.post(
   "/",
   requestValidationMiddleware(suggestionPostRequestSchema),


### PR DESCRIPTION
- Closes #1273 

- Added new Suggestion History tab, 
   - listed all suggestions for the stakeholder.
   - each suggestion has a text field, and status radio buttons users to update. 

- Added only "New" suggestions list to show on the top of the organization edit form

- When the organization edit form is submitted, if there are any changes made to the suggestions, the suggestions will also be updated. This includes buttons:
  -  Needs Verfication
  - (Re-)Assign
  - Request Changes
  - Approve 
  - Delete 
  - Hand Off 
  - Submit For Review 
  - Save Progress - Data Entry user
  - Save Progress - Admin user

Admin User recording:

https://github.com/user-attachments/assets/24affe36-b55e-486e-a0db-3e43c80ce78d

Data Entry User recording:

https://github.com/user-attachments/assets/5e3b1884-e9c1-400e-86c7-5d48269f1d84


