### PR TITLE
Update AnnouncementSnackbar to use MUI severity styling

### DIFF
--- a/client/src/components/UI/AnnouncementSnackbar.jsx
+++ b/client/src/components/UI/AnnouncementSnackbar.jsx
@@ -27,8 +27,7 @@ const AnnouncementSnackbar = () => {
       {enabledAnnouncements.map((announcement, idx) => (
         <Collapse in={openIndexes[idx]} key={announcement.id}>
           <Alert
-            icon={false}
-            severity="warning"
+            severity={announcement.severity || "info"}
             sx={{ mb: 0, p: 2 }}
             action={
               <IconButton
@@ -44,7 +43,7 @@ const AnnouncementSnackbar = () => {
               </IconButton>
             }
           >
-            <Typography>{announcement.description}</Typography>
+            <Typography variant="body1">{announcement.description}</Typography>
           </Alert>
         </Collapse>
       ))}


### PR DESCRIPTION
Closes #2502, #2503
  
## Summary
  Updates the AnnouncementSnackbar component to use severity styling instead of "warning". 
  Announcements now display with MUI Alert colors and icons based on their severity level (info, warning, error, success).

  ## Changes
  - Replace hardcoded `severity="warning"` with
  `severity={announcement.severity || "info"}`
  - Remove `icon={false}` to show default MUI severity icons

  ## Screenshot
<img width="1468" height="716" alt="Screenshot 2025-10-28 at 8 05 44 PM" src="https://github.com/user-attachments/assets/7ba9f40d-0f3e-48e8-8974-59236088d31e" />




