### PR TITLE
replace test for announcements #2500

### DIFF
--- a/client/tests/announcements.spec.ts
+++ b/client/tests/announcements.spec.ts
@@ -102,3 +102,34 @@ test.describe("Announcements", () => {
     await expect(page.getByText("warning")).toBeVisible();
   });
 });
+
+test.describe("Announcements", () => {
+  test("shows announcements when they're available", async ({ page }) => {
+    await mockRequests(page, {
+      announcements: [
+        {
+          id: 1,
+          title: "Test Announcement",
+          description: "This is a mock announcement for testing.",
+          is_enabled: true,
+          severity: "info",
+          created_at: "2025-10-30T10:00:00Z",
+        },
+      ],
+    });
+
+    await page.goto("/");
+    await expect(page.getByText("This is a mock announcement for testing.")).toBeVisible();
+
+    await page.goto("/organizations");
+    await expect(page.getByText("This is a mock announcement for testing.")).toBeVisible();
+  });
+
+  test("doesn't show announcements when there are none", async ({ page }) => {
+    await mockRequests(page, { announcements: [] });
+
+    await page.goto("/");
+    const announcementText = page.getByText("This is a mock announcement for testing.");
+    await expect(announcementText).toHaveCount(0);
+  });
+});

--- a/client/tests/app.spec.ts
+++ b/client/tests/app.spec.ts
@@ -9,11 +9,6 @@ test.describe("App", () => {
     await expect(
       page.getByText("Locate free food in Los Angeles")
     ).toBeVisible();
-    //await expect(
-    //page.getByText(
-    //"Due to the LA Fires, some information may be out-of-date."
-    //)
-    //).toBeVisible();
     await expect(page.getByText("Learn about this site")).toBeVisible();
     await expect(page.getByText("Learn about this site")).toHaveAttribute(
       "href",


### PR DESCRIPTION
- Resolves #2500 
- Removes the unused announcements test
- Replaces the previous test with one that verifies announcements are visible when they exist and confirms that no announcement is shown when none are present