### PR TITLE
Fix scroll position not resetting when navigating between routes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foodoasis-client",
-  "version": "1.0.96",
+  "version": "1.0.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foodoasis-client",
-      "version": "1.0.96",
+      "version": "1.0.100",
       "license": "GPL-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",

--- a/client/src/Routes.jsx
+++ b/client/src/Routes.jsx
@@ -1,3 +1,6 @@
+//Modify
+import ScrollToTop from "./components/ScrollToTop";
+
 import { CircularProgress, Grid, Stack } from "@mui/material";
 import Home from "components/FoodSeeker/Home";
 import Header from "components/Layout/Header";
@@ -73,9 +76,9 @@ export default function AppRoutes() {
         </Stack>
       }
     >
+      <ScrollToTop />
       {showSurveySnackbar && <SurveySnackbar />}
-
-      <Routes>
+      <Routes location={location} key={location.pathname}>
         <Route path="/" element={<AppWrapper />}>
           {/* Food seeker routes */}
           <Route index element={<Home />} />
@@ -237,6 +240,7 @@ function AppWrapper() {
         margin: "0",
         height: "100vh",
         overflowX: "hidden",
+        overflowY: "auto",
       }}
     >
       {isAlertLocation && <AnnouncementSnackbar />}

--- a/client/src/components/Layout/MenuItemLink.jsx
+++ b/client/src/components/Layout/MenuItemLink.jsx
@@ -1,15 +1,20 @@
 import { ListItem, ListItemText } from "@mui/material";
 import PropTypes from "prop-types";
-import { forwardRef, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { forwardRef, useMemo, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
 
 const MenuItemLink = ({ to, text, userSection, onClick }) => {
+  const location = useLocation();
   const renderLink = useMemo(
     () =>
       // eslint-disable-next-line react/display-name
       forwardRef((itemProps, ref) => <Link to={to} ref={ref} {...itemProps} />),
     [to]
   );
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   return (
     <span className={userSection}>

--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const scrollEl = document.querySelector("div[data-scroll-container]");
+
+    if (scrollEl) {
+      scrollEl.scrollTop = 0;
+    }
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
### What was happening
When navigating between pages (e.g. Home → Donate), the scroll position
was preserved, causing the new page to load already scrolled down.

### What I changed
- Added a ScrollToTop component triggered on route change
- Adjusted the AppWrapper container to allow proper vertical scrolling

### Result
Each route now starts at the top as expected.
