### PR TITLE
Fix: Reset scroll position when navigating between pages

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import * as analytics from "./services/analytics";
 import { AppStateProvider } from "./appReducer";
 import SEO from "./components/SEO";
 import AppRoutes from "./Routes";
+import ScrollToTop from "./components/Layout/ScrollToTop";
 import { MapProvider } from "react-map-gl";
 
 function App() {
@@ -34,6 +35,7 @@ function App() {
                 />
                 <MapProvider>
                   <Router>
+                    <ScrollToTop />
                     <AppRoutes />
                   </Router>
                 </MapProvider>

--- a/client/src/components/Layout/ScrollToTop.jsx
+++ b/client/src/components/Layout/ScrollToTop.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+/**
+ * ScrollToTop component
+ *
+ * This component automatically scrolls the window to the top whenever
+ * the route pathname changes. This ensures users see content from the
+ * beginning when navigating between pages.
+ *
+ * Usage: Place this component inside a Router but before the Routes component.
+ */
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop;


### PR DESCRIPTION
## Summary

Fixes #2662 - Scroll position not resetting when switching sidebar tabs

## Problem
When switching between different pages using the sidebar menu (e.g., About Us, FAQs, Donate), the scroll position from the previous page persisted instead of resetting to the top. This caused users to land in the middle or bottom of the new page's content instead of seeing it from the beginning.

## Solution
Added a  component that automatically scrolls the window to the top whenever the route pathname changes. This is a standard pattern in React Router applications.

## Changes
- **Created new component**: 
  - Uses  hook with  as a dependency
  - Calls  on route change
  - Well-documented with JSDoc comments

- **Updated**: 
  - Imported the  component
  - Placed it inside the  but before 
  - This ensures scroll resets on every navigation

## Testing
The fix can be tested by:
1. Opening any page with scrollable content (e.g., About Us)
2. Scrolling down to see more content
3. Clicking on a different menu item in the sidebar (e.g., FAQs)
4. The page should now scroll to the top automatically

## Impact
- Simple, focused change that addresses the reported bug
- Minimal code additions (new component + one import/placement)
- Follows standard React Router patterns
- Improves user experience across all navigation