### PR TITLE
Fix scroll position not resetting between routes

### DIFF
--- a/client/src/Routes.jsx
+++ b/client/src/Routes.jsx
@@ -11,6 +11,7 @@ import { useWidget } from "./appReducer";
 import useFeatureFlag from "./hooks/useFeatureFlag";
 import SurveySnackbar from "./components/UI/SurveySnackbar";
 import AnnouncementSnackbar from "components/UI/AnnouncementSnackbar";
+import ScrollToTop from "./components/ScrollToTop";
 
 const VerificationAdmin = lazy(() =>
   import("components/Admin/VerificationAdmin")
@@ -231,6 +232,7 @@ function AppWrapper() {
       wrap="nowrap"
       alignContent="stretch"
       spacing={0}
+      id="app-container"
       sx={{
         color: "black",
         backgroundColor: "#fff",
@@ -239,6 +241,7 @@ function AppWrapper() {
         overflowX: "hidden",
       }}
     >
+      <ScrollToTop />
       {isAlertLocation && <AnnouncementSnackbar />}
 
       {isWidget ? null : <Header />}

--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // Scroll the window
+    window.scrollTo(0, 0);
+
+    // Scroll the app container (Grid with fixed height)
+    const appContainer = document.getElementById("app-container");
+    if (appContainer) {
+      appContainer.scrollTop = 0;
+    }
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
#### Summary

  Fixes scroll position not resetting when navigating between static pages (About, Donate, FAQs, Contact, Suggest New Listing).

  #### Problem

When users scroll down on one page and navigate to another page via the sidebar menu, the new page would maintain the previous scroll position instead of starting at the top.

  This happened because the scroll was occurring on the Grid container with fixed height (100vh) rather than the browser window itself.

  #### Solution

  - Created a ScrollToTop component that uses React Router's useLocation hook to detect route changes
  - Added id="app-container" to the main Grid container for targeted scrolling
  - Component scrolls both the window and the app container to top on every route change

  #### Files Changed

  - client/src/components/ScrollToTop.jsx (new)
  - client/src/Routes.jsx

 Fixes #2662