### PR TITLE
Fix bug where Suggestions Admin screen had no results

### DIFF
--- a/client/src/services/suggestion-service.js
+++ b/client/src/services/suggestion-service.js
@@ -5,7 +5,10 @@ const baseUrl = "/api/suggestions";
 export const getAll = async (statusIds) => {
   try {
     const params = { statusIds, tenantId: TENANT_ID };
-    const response = await axios.get(baseUrl, { params });
+    const response = await axios.get(baseUrl, {
+      params,
+      paramsSerializer: { indexes: null }, // This will prevent axios from adding [] to the query parameters
+    });
     return response.data;
   } catch (err) {
     throw new Error(err.message);


### PR DESCRIPTION
Fixes #2678 

### Bug

Problem was in the way that the axios package formats query string parameters for a parameter of type array.  I think this is the only web api GET request in the application that passes an array parameter in a GET request, to pass the array of statuses that the user wants to see.  Axios was formatting the url like this:

```
https://devla.foodoasis.net/api/suggestions?statusIds%5B%5D=1&statusIds%5B%5D=2&statusIds%5B%5D=3&statusIds%5B%5D=4&tenantId=1
```
The `%5B%5D` characters inserted in the query string are left and right square brackets [], which is one way to represent an array.  Unencoding the above backets would be more readable:

```
https://devla.foodoasis.net/api/suggestions?statusIds[]=1&statusIds[]=2&statusIds[]=3&statusIds[]=4&tenantId=1
```
However, the web api server is expecting a different convention that omits the square brackets:

```
https://devla.foodoasis.net/api/suggestions?statusIds=1&statusIds=2&statusIds=3&statusIds=4&tenantId=1
```

Since the server was unable to decode the array of statusIds requested, it was returning nothing.

### Fix
Since this was working before, it is most likely that this bug was introduced when the axios library was updated recently, and they changed the default convention for how array-type query string parameters are encoded in the url.

To fix this, we need to change the configuration for the Axios paramsSerializer to omit the brackets like so in the client/stc/services.suggestion-service code:

```
export const getAll = async (statusIds) => {
  try {
    const params = { statusIds, tenantId: TENANT_ID };
    const response = await axios.get(baseUrl, {
      params,
      paramsSerializer: { indexes: null }, // This will prevent axios from adding [] to the query parameters
    });
    return response.data;
  } catch (err) {
    throw new Error(err.message);
  }
};
```








