### PR TITLE
Fix stakeholder Details view on mobile

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderDetails/StakeholderDetails.jsx
@@ -40,7 +40,6 @@ import {
   useSelectedOrganization,
   useUserCoordinates,
   useWidget,
-  usePosition,
 } from "../../../../appReducer";
 import { useToasterContext } from "../../../../contexts/toasterContext";
 import SEO from "../../../SEO";
@@ -96,8 +95,6 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
   const navigate = useNavigate();
   const { setToast } = useToasterContext();
   const { tenantTimeZone } = useSiteContext();
-  const position = usePosition();
-  const [paddingBottom, setPaddingBottom] = useState(30);
 
   const foodTypes = useMemo(() => {
     return (
@@ -112,32 +109,6 @@ const StakeholderDetails = ({ onBackClick, isDesktop }) => {
         : "")
     );
   }, [selectedOrganization]);
-
-  useEffect(() => {
-    const windowHeight = window.innerHeight / 100;
-    if (
-      position.y === (100 / window.innerHeight) * 54 * windowHeight ||
-      position.y === 0 * windowHeight
-    ) {
-      setPaddingBottom(200);
-    } else if (position.y === 17 * windowHeight) {
-      setPaddingBottom(300);
-    }
-  }, [position]);
-
-  // USE EFFECT BASED ON THIS FUNCTION IN Mobile.js
-  // const handleStop = (e, ui) => {
-  //   const windowHeight = window.innerHeight / 100;
-  //   let newY;
-  //   if (ui.y < 20 * windowHeight) {
-  //     newY = hasAdvancedFilterFeatureFlag ? (100 / window.innerHeight) * 60 : 0;
-  //   } else if (ui.y > 20 * windowHeight && ui.y < 40 * windowHeight) {
-  //     newY = 17;
-  //   } else if (ui.y > 40 * windowHeight) {
-  //     newY = 54;
-  //   }
-  //   setPosition({ x: 0, y: newY * windowHeight });
-  // };
 
   useEffect(() => {
     if (selectedOrganization?.id) {

--- a/client/src/components/FoodSeeker/SearchResults/layouts/Mobile.jsx
+++ b/client/src/components/FoodSeeker/SearchResults/layouts/Mobile.jsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import { useEffect, useState } from "react";
 import Draggable from "react-draggable";
 import { useFilterPanel } from "appReducer";
@@ -6,14 +6,18 @@ import AttributionInfo from "../AttributionInfo";
 import { useAppDispatch } from "../../../../appReducer";
 import useFeatureFlag from "hooks/useFeatureFlag";
 
-const overlay = {
+const getOverlayStyle = (positionY) => ({
   position: "absolute",
   width: "100%",
-  height: "100%",
+  top: 0,
+  bottom: `${positionY}px`,
   backgroundColor: "transparent",
   zIndex: 1000,
   borderRadius: "10px",
-};
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+});
 
 const MobileLayout = ({ filters, map, list, showList }) => {
   const filterPanelOpen = useFilterPanel();
@@ -24,14 +28,6 @@ const MobileLayout = ({ filters, map, list, showList }) => {
     x: 0,
     y: initialY * (window.innerHeight / 100),
   });
-
-  // disable body scroll
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-    });
-    document.body.style.overflow = "hidden";
-  }, []);
 
   useEffect(() => {
     dispatch({ type: "POSITION", position: position });
@@ -47,6 +43,10 @@ const MobileLayout = ({ filters, map, list, showList }) => {
 
     setPosition({ x: 0, y: newY * (window.innerHeight / 100) });
   }, [showList, filterPanelOpen, hasAdvancedFilterFeatureFlag]);
+
+  const handleDrag = (e, ui) => {
+    setPosition({ x: 0, y: ui.y });
+  };
 
   const handleStop = (e, ui) => {
     const windowHeight = window.innerHeight / 100;
@@ -75,7 +75,7 @@ const MobileLayout = ({ filters, map, list, showList }) => {
 
   return (
     <>
-      {filters}
+      <Box>{filters}</Box>
       <Box
         sx={{
           height: window.innerHeight,
@@ -100,6 +100,7 @@ const MobileLayout = ({ filters, map, list, showList }) => {
         {list && (
           <Draggable
             position={position}
+            onDrag={handleDrag}
             onStop={handleStop}
             handle=".handle"
             bounds={{ top: 0, bottom: minY * (window.innerHeight / 100) }}
@@ -111,8 +112,7 @@ const MobileLayout = ({ filters, map, list, showList }) => {
               backgroundColor: "white",
             }}
           >
-            <Box sx={overlay}>
-              <Grid container spacing={0}></Grid>
+            <Box sx={getOverlayStyle(position.y)}>
               <Box
                 sx={{
                   width: "100vw",
@@ -143,8 +143,9 @@ const MobileLayout = ({ filters, map, list, showList }) => {
               <Box
                 sx={{
                   backgroundColor: "white",
-                  height: "100%",
+                  flex: 1,
                   width: "100vw",
+                  overflow: "hidden",
                 }}
               >
                 {list}


### PR DESCRIPTION
  ## Summary
  Fixed mobile view for stakeholder details by refactoring the logic to give the stakeholder parent (Mobile.jsx) a responsive height that never exceeds the bottom of the device.

  ## Problem
  The StakeholderDetails component had position tracking logic to add padding based on the draggable panel position, but this approach needed to be fixed every time a new component was added.

  If added at the top of StakeholderDetails (announcements for example), the StakeholderDetails parent would extend past the bottom of the device, making it impossible to see the last part of the stakeholder
  information.

  <img width="324" height="700" alt="Screenshot 2026-02-16 at 6 21 36 PM" src="https://github.com/user-attachments/assets/3df742b6-f418-40b4-ab94-20926a39f851" />

  Adding a new component to the bottom (outdated information) it would not show up since the parent end is behind the bottom of the device and the padding bottom is not enough to bring the component back into view.

  <img width="430" height="429" alt="Screenshot 2026-02-16 at 6 21 57 PM" src="https://github.com/user-attachments/assets/3fd13340-bd63-4567-b393-43496d34b341" />

  ![record bottom](https://github.com/user-attachments/assets/60216a37-5341-4a83-b9ce-5c52c68c2d12)

  ## Solution
  The solution is not straightforward because the overlay has `position: absolute`, so managing its height is not as simple as using `flex: 1` like we would in a normal flexbox flow.

  The new implementation controls the height of the overlay dynamically using `positionY`. Instead of the panel extending beyond the bottom of the device, the `bottom` property is calculated using `positionY`.

  When the user drags the panel, `positionY` recalculates the overlay height as the difference between the screen height and the distance from the top of the screen to the handle. This recalculation happens on every drag event, so the overlay always ends exactly at the bottom of the screen.

  This means adding or changing components inside StakeholderDetails will never break the layout, since the height is always driven by the panel position, not by hardcoded padding values.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/f3090f90-0f6f-4304-8174-c63d745c9f2b" /> | <video src="https://github.com/user-attachments/assets/7a01b6fb-dfaf-4328-bfe8-ffa1445a6cc8" /> |

  ## Changes
  - Removed `usePosition` and `paddingBottom` state from StakeholderDetails
  - Removed useEffect that added padding bottom based on position
  - Renamed `overlay` to `getOverlayStyle` and passed `positionY` as parameter
  - Removed `height: 100%` to use `top: 0` and `bottom: positionY` instead
  - Added flexbox to enable `flex: 1` for content to fill available space without exceeding device height in Mobile.jsx
  - Added `handleDrag` handler for handling position updates during drag
  - Added Box wrapper to show filters toolbar

  ## Test
  - [ ] Verify draggable panel moves smoothly on mobile
  - [ ] Confirm StakeholderDetails content is fully scrollable
  - [ ] Check that filters toolbar displays correctly
  - [ ] Test panel snapping behavior at different positions
  - [ ] Add new components to StakeholderDetails and verify layout doesn't break
  
  
  Fix #2661  
