### PR TITLE
Restrict data entry users to assigned stakeholders on server-side

### DIFF
--- a/server/__test__/stakeholder-controller.test.ts
+++ b/server/__test__/stakeholder-controller.test.ts
@@ -1,0 +1,110 @@
+import stakeholderController from "../app/controllers/stakeholder-controller";
+import stakeholderService from "../app/services/stakeholder-service";
+import { mockNext, mockRequest, mockResponse } from "./utils";
+
+jest.mock("../app/services/stakeholder-service");
+
+const selectByIdMock = stakeholderService.selectById as jest.MockedFunction<
+  typeof stakeholderService.selectById
+>;
+const isStakeholderAssignedToUserMock =
+  stakeholderService.isStakeholderAssignedToUser as jest.MockedFunction<
+    typeof stakeholderService.isStakeholderAssignedToUser
+  >;
+const updateMock = stakeholderService.update as jest.MockedFunction<
+  typeof stakeholderService.update
+>;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("Stakeholder controller authorization", () => {
+  it("blocks data entry users from reading unassigned stakeholders", async () => {
+    const req = mockRequest({
+      params: { id: "42" },
+      user: { id: "7", sub: "data_entry" },
+    });
+    const res = mockResponse();
+    const next = mockNext();
+    isStakeholderAssignedToUserMock.mockResolvedValue(false);
+
+    await stakeholderController.getById(req, res, next);
+
+    expect(isStakeholderAssignedToUserMock).toHaveBeenCalledWith(42, 7);
+    expect(selectByIdMock).not.toHaveBeenCalled();
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+  });
+
+  it("allows data entry users to read assigned stakeholders", async () => {
+    const req = mockRequest({
+      params: { id: "42" },
+      user: { id: "7", sub: "data_entry" },
+    });
+    const res = mockResponse();
+    const next = mockNext();
+    const stakeholder = { id: 42, name: "Assigned stakeholder" } as any;
+    isStakeholderAssignedToUserMock.mockResolvedValue(true);
+    selectByIdMock.mockResolvedValue(stakeholder);
+
+    await stakeholderController.getById(req, res, next);
+
+    expect(isStakeholderAssignedToUserMock).toHaveBeenCalledWith(42, 7);
+    expect(selectByIdMock).toHaveBeenCalledWith("42");
+    expect(res.send).toHaveBeenCalledWith(stakeholder);
+  });
+
+  it("blocks data entry users from updating unassigned stakeholders", async () => {
+    const req = mockRequest({
+      params: { id: "42" },
+      body: { id: 99, name: "Updated stakeholder" },
+      user: { id: "7", sub: "data_entry" },
+    });
+    const res = mockResponse();
+    const next = mockNext();
+    isStakeholderAssignedToUserMock.mockResolvedValue(false);
+
+    await stakeholderController.put(req, res, next);
+
+    expect(isStakeholderAssignedToUserMock).toHaveBeenCalledWith(42, 7);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+  });
+
+  it("uses the route id as the source of truth for updates", async () => {
+    const req = mockRequest({
+      params: { id: "42" },
+      body: { id: 99, name: "Updated stakeholder" },
+      user: { id: "7", sub: "data_entry" },
+    });
+    const res = mockResponse();
+    const next = mockNext();
+    isStakeholderAssignedToUserMock.mockResolvedValue(true);
+
+    await stakeholderController.put(req, res, next);
+
+    expect(isStakeholderAssignedToUserMock).toHaveBeenCalledWith(42, 7);
+    expect(updateMock).toHaveBeenCalledWith({
+      id: 42,
+      name: "Updated stakeholder",
+    });
+    expect(res.sendStatus).toHaveBeenCalledWith(200);
+  });
+
+  it("does not apply assignment checks to admins", async () => {
+    const req = mockRequest({
+      params: { id: "42" },
+      user: { id: "1", sub: "admin,data_entry" },
+    });
+    const res = mockResponse();
+    const next = mockNext();
+    const stakeholder = { id: 42, name: "Any stakeholder" } as any;
+    selectByIdMock.mockResolvedValue(stakeholder);
+
+    await stakeholderController.getById(req, res, next);
+
+    expect(isStakeholderAssignedToUserMock).not.toHaveBeenCalled();
+    expect(selectByIdMock).toHaveBeenCalledWith("42");
+    expect(res.send).toHaveBeenCalledWith(stakeholder);
+  });
+});

--- a/server/app/controllers/stakeholder-controller.ts
+++ b/server/app/controllers/stakeholder-controller.ts
@@ -2,6 +2,10 @@ import stakeholderService from "../services/stakeholder-service";
 import { Readable } from "stream";
 import { RequestHandler } from "express";
 import {
+  getAuthenticatedUserId,
+  hasStakeholderAccess,
+} from "../helpers/stakeholder-access";
+import {
   StakeholderSearchParams,
   Stakeholder,
   ClaimParams,
@@ -11,57 +15,6 @@ import {
   NeedsVerificationParams,
 } from "../../types/stakeholder-types";
 import { stringify } from "csv-stringify";
-
-type OwnershipRequest = {
-  user?: {
-    id?: string;
-    role?: string;
-    sub?: string;
-  };
-};
-
-type OwnershipResponse = {
-  sendStatus: (code: number) => unknown;
-};
-
-const getUserRoles = (req: OwnershipRequest) =>
-  new Set((req.user?.sub || req.user?.role || "").split(",").filter(Boolean));
-
-const isRestrictedDataEntryUser = (req: OwnershipRequest) => {
-  const roles = getUserRoles(req);
-  return (
-    roles.has("data_entry") && !roles.has("admin") && !roles.has("coordinator")
-  );
-};
-
-const getAuthenticatedUserId = (req: OwnershipRequest) => Number(req.user?.id || 0);
-
-const ensureStakeholderAccess = async (
-  req: OwnershipRequest,
-  res: OwnershipResponse,
-  stakeholderId: number
-) => {
-  if (!isRestrictedDataEntryUser(req)) {
-    return true;
-  }
-
-  const userId = getAuthenticatedUserId(req);
-  if (!userId) {
-    res.sendStatus(401);
-    return false;
-  }
-
-  const isAssigned = await stakeholderService.isStakeholderAssignedToUser(
-    stakeholderId,
-    userId
-  );
-  if (!isAssigned) {
-    res.sendStatus(403);
-    return false;
-  }
-
-  return true;
-};
 
 const search: RequestHandler<
   never,
@@ -113,7 +66,13 @@ const getById: RequestHandler<
 > = async (req, res) => {
   try {
     const stakeholderId = Number(req.params.id);
-    if (!(await ensureStakeholderAccess(req, res, stakeholderId))) {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) {
+      res.sendStatus(401);
+      return;
+    }
+    if (!(await hasStakeholderAccess(req.user, stakeholderId))) {
+      res.sendStatus(403);
       return;
     }
     const resp = await stakeholderService.selectById(req.params.id);
@@ -229,7 +188,13 @@ const put: RequestHandler<
 > = async (req, res) => {
   try {
     const stakeholderId = Number(req.params.id);
-    if (!(await ensureStakeholderAccess(req, res, stakeholderId))) {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) {
+      res.sendStatus(401);
+      return;
+    }
+    if (!(await hasStakeholderAccess(req.user, stakeholderId))) {
+      res.sendStatus(403);
       return;
     }
     await stakeholderService.update({

--- a/server/app/controllers/stakeholder-controller.ts
+++ b/server/app/controllers/stakeholder-controller.ts
@@ -265,9 +265,18 @@ const requestAssignment: RequestHandler<
   never
 > = async (req, res) => {
   try {
-    const count = await stakeholderService.requestAssignment(req.body);
+    const loginId = getAuthenticatedUserId(req);
+    if (!loginId) {
+      res.sendStatus(401);
+      return;
+    }
+    const count = await stakeholderService.requestAssignment({
+      ...req.body,
+      loginId,
+    });
     if (count === 0) {
       res.status(404).send({ error: "No stakeholders found" });
+      return;
     }
     res.sendStatus(200);
   } catch (err) {

--- a/server/app/controllers/stakeholder-controller.ts
+++ b/server/app/controllers/stakeholder-controller.ts
@@ -12,6 +12,57 @@ import {
 } from "../../types/stakeholder-types";
 import { stringify } from "csv-stringify";
 
+type OwnershipRequest = {
+  user?: {
+    id?: string;
+    role?: string;
+    sub?: string;
+  };
+};
+
+type OwnershipResponse = {
+  sendStatus: (code: number) => unknown;
+};
+
+const getUserRoles = (req: OwnershipRequest) =>
+  new Set((req.user?.sub || req.user?.role || "").split(",").filter(Boolean));
+
+const isRestrictedDataEntryUser = (req: OwnershipRequest) => {
+  const roles = getUserRoles(req);
+  return (
+    roles.has("data_entry") && !roles.has("admin") && !roles.has("coordinator")
+  );
+};
+
+const getAuthenticatedUserId = (req: OwnershipRequest) => Number(req.user?.id || 0);
+
+const ensureStakeholderAccess = async (
+  req: OwnershipRequest,
+  res: OwnershipResponse,
+  stakeholderId: number
+) => {
+  if (!isRestrictedDataEntryUser(req)) {
+    return true;
+  }
+
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) {
+    res.sendStatus(401);
+    return false;
+  }
+
+  const isAssigned = await stakeholderService.isStakeholderAssignedToUser(
+    stakeholderId,
+    userId
+  );
+  if (!isAssigned) {
+    res.sendStatus(403);
+    return false;
+  }
+
+  return true;
+};
+
 const search: RequestHandler<
   never,
   Stakeholder[] | { error: string },
@@ -61,6 +112,10 @@ const getById: RequestHandler<
   never
 > = async (req, res) => {
   try {
+    const stakeholderId = Number(req.params.id);
+    if (!(await ensureStakeholderAccess(req, res, stakeholderId))) {
+      return;
+    }
     const resp = await stakeholderService.selectById(req.params.id);
     res.send(resp);
   } catch (err: any) {
@@ -167,13 +222,20 @@ const post: RequestHandler<
 };
 
 const put: RequestHandler<
-  never,
+  { id: string },
   never,
   InsertStakeholderParams,
   never
 > = async (req, res) => {
   try {
-    await stakeholderService.update(req.body);
+    const stakeholderId = Number(req.params.id);
+    if (!(await ensureStakeholderAccess(req, res, stakeholderId))) {
+      return;
+    }
+    await stakeholderService.update({
+      ...req.body,
+      id: stakeholderId,
+    });
     res.sendStatus(200);
   } catch (err) {
     console.error(err);

--- a/server/app/controllers/stakeholder-controller.ts
+++ b/server/app/controllers/stakeholder-controller.ts
@@ -2,8 +2,8 @@ import stakeholderService from "../services/stakeholder-service";
 import { Readable } from "stream";
 import { RequestHandler } from "express";
 import {
+  assertHasStakeholderAccess,
   getAuthenticatedUserId,
-  hasStakeholderAccess,
 } from "../helpers/stakeholder-access";
 import {
   StakeholderSearchParams,
@@ -71,14 +71,13 @@ const getById: RequestHandler<
       res.sendStatus(401);
       return;
     }
-    if (!(await hasStakeholderAccess(req.user, stakeholderId))) {
-      res.sendStatus(403);
-      return;
-    }
+    await assertHasStakeholderAccess(req.user, stakeholderId);
     const resp = await stakeholderService.selectById(req.params.id);
     res.send(resp);
   } catch (err: any) {
-    if (err.code === 0) {
+    if (err.statusCode) {
+      res.sendStatus(err.statusCode);
+    } else if (err.code === 0) {
       res.sendStatus(404);
     } else {
       console.error(err);
@@ -193,18 +192,19 @@ const put: RequestHandler<
       res.sendStatus(401);
       return;
     }
-    if (!(await hasStakeholderAccess(req.user, stakeholderId))) {
-      res.sendStatus(403);
-      return;
-    }
+    await assertHasStakeholderAccess(req.user, stakeholderId);
     await stakeholderService.update({
       ...req.body,
       id: stakeholderId,
     });
     res.sendStatus(200);
-  } catch (err) {
-    console.error(err);
-    res.sendStatus(500);
+  } catch (err: any) {
+    if (err.statusCode) {
+      res.sendStatus(err.statusCode);
+    } else {
+      console.error(err);
+      res.sendStatus(500);
+    }
   }
 };
 

--- a/server/app/helpers/stakeholder-access.ts
+++ b/server/app/helpers/stakeholder-access.ts
@@ -1,0 +1,47 @@
+import stakeholderService from "../services/stakeholder-service";
+
+type StakeholderAccessUser = {
+  id?: string;
+  role?: string;
+  sub?: string;
+};
+
+type StakeholderAccessRequest = {
+  user?: {
+    id?: string;
+    role?: string;
+    sub?: string;
+  };
+};
+
+const getUserRoles = (user?: StakeholderAccessUser) =>
+  new Set((user?.sub || user?.role || "").split(",").filter(Boolean));
+
+const isRestrictedDataEntryUser = (user?: StakeholderAccessUser) => {
+  const roles = getUserRoles(user);
+  return (
+    roles.has("data_entry") && !roles.has("admin") && !roles.has("coordinator")
+  );
+};
+
+export const getAuthenticatedUserId = (req: StakeholderAccessRequest) =>
+  Number(req.user?.id || 0);
+
+export const hasStakeholderAccess = async (
+  user: StakeholderAccessUser | undefined,
+  stakeholderId: number
+) => {
+  if (!isRestrictedDataEntryUser(user)) {
+    return true;
+  }
+
+  const userId = Number(user?.id || 0);
+  if (!userId) {
+    return false;
+  }
+
+  return stakeholderService.isStakeholderAssignedToUser(
+    stakeholderId,
+    userId
+  );
+};

--- a/server/app/helpers/stakeholder-access.ts
+++ b/server/app/helpers/stakeholder-access.ts
@@ -6,6 +6,10 @@ type StakeholderAccessUser = {
   sub?: string;
 };
 
+type StakeholderAccessError = Error & {
+  statusCode: number;
+};
+
 type StakeholderAccessRequest = {
   user?: {
     id?: string;
@@ -44,4 +48,18 @@ export const hasStakeholderAccess = async (
     stakeholderId,
     userId
   );
+};
+
+export const assertHasStakeholderAccess = async (
+  user: StakeholderAccessUser | undefined,
+  stakeholderId: number
+) => {
+  const hasAccess = await hasStakeholderAccess(user, stakeholderId);
+  if (hasAccess) {
+    return;
+  }
+
+  const error = new Error("Forbidden") as StakeholderAccessError;
+  error.statusCode = 403;
+  throw error;
 };

--- a/server/app/services/stakeholder-service.ts
+++ b/server/app/services/stakeholder-service.ts
@@ -254,6 +254,20 @@ const selectById = async (id: string): Promise<Stakeholder> => {
   return stakeholderHelpers.rowToStakeholder(row);
 };
 
+const isStakeholderAssignedToUser = async (
+  stakeholderId: number,
+  loginId: number
+): Promise<boolean> => {
+  const sql = `select exists(
+    select 1
+    from stakeholder
+    where id = $<stakeholderId>
+    and assigned_login_id = $<loginId>
+  ) as allowed`;
+  const result = await db.one(sql, { stakeholderId, loginId });
+  return result.allowed;
+};
+
 const selectCsv = async (ids: string[]): Promise<Stakeholder[]> => {
   const sql = `select
   s.id, s.name, s.address_1, s.address_2, s.city, s.state, s.zip,
@@ -805,6 +819,7 @@ const buildLoginSelectsClause = () => {
 export default {
   search,
   selectById,
+  isStakeholderAssignedToUser,
   selectCsv,
   insert,
   insertBulk,

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -1,2 +1,14 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 require("dotenv").config();
+
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.(ts|tsx|js)$": "babel-jest",
+  },
+  moduleFileExtensions: ["ts", "tsx", "js", "json"],
+  testPathIgnorePatterns: ["/node_modules/", "/build/"],
+  transformIgnorePatterns: [
+    "/node_modules/(?!(camelcase-keys|camelcase|map-obj|quick-lru|uuid)/)",
+  ],
+};

--- a/server/types/express.d.ts
+++ b/server/types/express.d.ts
@@ -4,6 +4,7 @@ declare namespace Express {
       email?: string;
       id?: string;
       role?: string;
+      sub?: string;
       firstName?: string;
       lastName?: string;
       features?: string[];

--- a/server/types/stakeholder-types.ts
+++ b/server/types/stakeholder-types.ts
@@ -190,7 +190,7 @@ export interface ClaimParams {
 
 export interface RequestAssignmentParams {
   tenantId: number;
-  loginId: number;
+  loginId?: number;
 }
 
 export interface AssignParams {


### PR DESCRIPTION
  ## Summary
Add server-side restriction for stakeholder `GET` and `PUT` requests so backend access matches the UI restrictions for Data Entry users.

  ## Problem
Any Data Entry user can read and update stakeholder records through postman or the terminal, bypassing the UI restrictions.  

  ## Solution
  Add server-side validation to verify that a Data Entry user making a GET or PUT request is assigned to the stakeholder they are trying to read or modify.

| Before | After |
|--------|-------|
|  <img width="752" height="743" alt="2711 before" src="https://github.com/user-attachments/assets/1afaee29-c10e-4d36-b6cb-6d328fe5aa8e" /> |  <img width="752" height="743" alt="2711 after" src="https://github.com/user-attachments/assets/51581acb-9b61-466c-a392-add85db0c79e" /> |
|  <img width="752" height="779" alt="2711 before 1" src="https://github.com/user-attachments/assets/e682a8c3-b223-441f-97d9-aed548a15452" /> | <img width="759" height="404" alt="2711 after 1" src="https://github.com/user-attachments/assets/e4a66d3f-1cd0-4409-956b-4c34dea87887" />  |


  ## Changes

- stakeholder-controller.ts
      - Add a server-side ownership check for Data Entry users
      - Block GET and PUT when the authenticated Data Entry user is not assigned to the stakeholder
      - requestAssignment now uses the authenticated user id from the JWT instead of client-provided (request.body) loginId
- stakeholder-service.ts
      - Add isStakeholderAssignedToUser to verify whether a stakeholder is assigned to a specific user
- express.d.ts
      - Add sub to the request user type so the controller can read user roles from the JWT payload
- stakeholder-controller.test.ts
      - Add tests to verify:
          - unassigned stakeholders cannot be read by Data Entry users
          - assigned stakeholders can be read by Data Entry users
          - unassigned stakeholders cannot be updated by Data Entry users
          - admin users are not blocked by this restriction

  ## Test

npm test on `server`
npm run typecheck on `server`
npm test on `client`
npm run build 
Test backend manually: Follow screenshots  to test endpoints
Test frontend manually: Login with data entry user, request an assignment, try to change the ID in the URL to access another stakeholder(should show 403 on console and an empty form).



Fixes #2711 