### PR TITLE
Add server-side validation for editing announcements

### DIFF
--- a/server/app/routes/announcements-router.ts
+++ b/server/app/routes/announcements-router.ts
@@ -22,6 +22,7 @@ router.delete(
 router.put(
   "/:id",
   jwtSession.validateUserHasRequiredRoles(["admin"]),
+  requestValidationMiddleware(AnnouncementsPostRequestSchema),
   announcementsController.update
 );
 


### PR DESCRIPTION
  ## Summary
Add server-side restriction for announcements `PUT` requests so backend matches the UI restrictions.

  ## Problem
Right now we can send a request from the terminal/postman without following the UI fields. For example a PUT request without title will reach the database query and server is gonna reply with error 500. 

  ## Solution
  Use the same request validation schema used by POST /api/announcements.



  ## Test

- npm test in server
- npm run typecheck in server
- npm test in client
- npm run build
- Manual backend test:
      - valid PUT /api/announcements/:id payload returns success
      - invalid PUT /api/announcements/:id payload returns 400



Fixes #2533 