### PR TITLE
Fix Docker build for load controller CSV export

### DIFF
--- a/server/app/controllers/load-controller.ts
+++ b/server/app/controllers/load-controller.ts
@@ -7,7 +7,7 @@ import { LARFBListing } from "../../types/load-larfb-types";
 import loadLARFBService from "../services/load-larfb-service";
 import { LA211Listing } from "../../types/load-211-types";
 import load211Service from "../services/load-211-service";
-import { json2csvAsync } from "json-2-csv";
+import { json2csv } from "json-2-csv";
 
 // Allow viewing (not editing) data loaded by imports
 // and scrapers.
@@ -28,7 +28,7 @@ const getLaplFoodResources: RequestHandler<
     if (req.query.format === "json" || req.accepts("json")) {
       res.send(rows);
     } else {
-      const csv = await json2csvAsync(rows);
+      const csv = await json2csv(rows);
       res.setHeader("Content-Type", "text/csv");
       res.setHeader(
         "Content-Disposition",
@@ -57,7 +57,7 @@ const getOpenLA: RequestHandler<
     if (req.query.format === "json" || req.accepts("json")) {
       res.send(rows);
     } else {
-      const csv = await json2csvAsync(rows);
+      const csv = await json2csv(rows);
       res.setHeader("Content-Type", "text/csv");
       res.setHeader(
         "Content-Disposition",
@@ -87,7 +87,7 @@ const getLARFB: RequestHandler<
     if (req.query.format === "json" || req.accepts("json")) {
       res.send(resp);
     } else {
-      const csv = await json2csvAsync(resp);
+      const csv = await json2csv(resp);
       res.setHeader("Content-Type", "text/csv");
       res.setHeader(
         "Content-Disposition",


### PR DESCRIPTION
  ## Summary
Fix the Docker build after merging #2720.

  ## Problem
During Monday's meeting Hannah and I noticed typescript errors about server/app/controllers/load-controller.ts. 

> app/controllers/load-controller.ts(31,25): error TS2554: Expected 2-3 arguments, but got 1.

To fix the error I changed the function `json2csv` to `json2csvAsync`. That worked on my machine and passed the tests and the npm run build command without errors so I merged it. Then I got the lovely email saying the Docker build failed, and I had to go down the rabbit hole to figure out why. I remembered something similar happened to me before on #2554.

The Docker build error was: 

> 24 [serverbuilder 13/13] RUN npm ci --quiet && npm run build
> 
> 24 18.55 app/controllers/load-controller.ts(10,10): error TS2305: Module '"json-2-csv"' has no exported member 'json2csvAsync'.
> 
> 24 ERROR: process "/bin/sh -c npm ci --quiet && npm run build" did not complete successfully: exit code: 2

Going back a couple of commits makes it clearer. 

On  Jan 18 #2634 We updated the package  `"json-2-csv": "^3.17.1",` to `"json-2-csv": "^5.5.10"`

Right after that on  #2638 `load-controller.ts` changed from: 

```
json2csv(rows, (_err: Error | undefined, csv: string | undefined) => {
        res.setHeader("Content-Type", "text/csv");
        res.setHeader(
          "Content-Disposition",
          'attachment; filename="' +
            "lapl-food-resources-" +
            Date.now() +
            '.csv"'
        );
        res.send(csv);
      });
```
      
      To 
      
```
 const csv = await json2csv(rows);
      res.setHeader("Conte  nt-Type", "text/csv");
      res.setHeader(
        "Content-Disposition",
        'attachment; filename="' + "lapl-food-resources-" + Date.now() + '.csv"'
      );

      res.send(csv);
```

That change was made by John because the jump from version 3 to version 5 changed the json2csv function from a callback-based function to one that can be used as an async function.

Now, on my machine I was still running version 3 so I was  getting the typecheck error:
> app/controllers/load-controller.ts(31,25): error TS2554: Expected 2-3 arguments, but got 1.

I should have realized that if the docker build was successful and live already the problem had to be with my local environment, not the code itself. But I was sure I could fix the typecheck switching from `json2csv` to `json2csvAsync`:

```
const csv = await json2csvAsync(rows);
```
And it worked on my machine because this was one of the ways to use json2csv as an async call in version 3, but version 5 doesnt export  json2csvAsync anymore and json2csv now takes only 1 parameter. 

This is why the same function was working live, but it was giving me a typecheck error locally. 

  ## Solution

Go back to the original `await json2csv(...)`. 
Use npm ci before npm run build next time I test or before working on an issue, especially after dependency updates.
It could also be worth adding a Docker build check to CI on PRs, so issues like this get caught before merging into develop.

I’ll bring that up in the next meeting.

  ## Changes

  - go back to await json2csv(..) 

  ## Test

cd server 
rm -rf node_modules             
npm ci
npm run build
