### PR TITLE
Fix address bar behavior on fast typing

### DIFF
--- a/client/src/components/FoodSeeker/AddressDropDown.jsx
+++ b/client/src/components/FoodSeeker/AddressDropDown.jsx
@@ -28,7 +28,13 @@ export default function AddressDropDown({ autoFocus }) {
     searchCoordinates?.locationName || ""
   );
   const [open, setOpen] = useState(false);
-  const { mapboxResults, fetchMapboxResults, isLoading } = useMapboxGeocoder();
+  const {
+    mapboxResults,
+    searchMapboxResults,
+    ensureMapboxResults,
+    isLoading,
+    resultsQuery,
+  } = useMapboxGeocoder();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const { flyTo } = useMapbox();
@@ -76,10 +82,9 @@ export default function AddressDropDown({ autoFocus }) {
   const handleInputChange = (delta) => {
     if (!delta) return;
     const safeValue = typeof delta === "string" ? delta : delta.target.value;
+    setHighlightedOption(null);
     setInputVal(safeValue);
-    if (safeValue) {
-      fetchMapboxResults(safeValue);
-    }
+    searchMapboxResults(safeValue);
   };
 
   const handleAutocompleteOnChange = (selectedResult) => {
@@ -206,12 +211,30 @@ export default function AddressDropDown({ autoFocus }) {
     );
   };
 
-  const handleKeyDown = (event) => {
-    if (event.key === "Enter" && !isLoading) {
+  const handleKeyDown = async (event) => {
+    if (event.key === "Enter") {
       event.preventDefault();
-      if (mapboxOptions.length > 0) {
-        const selected = highlightedOption ?? mapboxOptions[0];
-        handleAutocompleteOnChange(selected);
+
+      const normalizedInput = inputVal.trim();
+      if (!normalizedInput) {
+        return;
+      }
+
+      const hasCurrentAddressResults =
+        !isLoading && resultsQuery === normalizedInput;
+
+      if (hasCurrentAddressResults && highlightedOption?.type === "mapbox") {
+        handleAutocompleteOnChange(highlightedOption);
+        return;
+      }
+
+      const resolvedResults = await ensureMapboxResults(normalizedInput);
+
+      if (resolvedResults.length > 0) {
+        handleAutocompleteOnChange({
+          type: "mapbox",
+          value: resolvedResults[0],
+        });
       }
     }
   };

--- a/client/src/hooks/useMapboxGeocoder.js
+++ b/client/src/hooks/useMapboxGeocoder.js
@@ -5,7 +5,7 @@ import {
   MAPBOX_ACCESS_TOKEN,
   DEFAULT_VIEWPORTS,
 } from "helpers/Constants";
-import { useCallback, useReducer } from "react";
+import { useCallback, useReducer, useRef } from "react";
 
 const baseUrl = `https://api.mapbox.com/geocoding/v5/mapbox.places`;
 
@@ -13,6 +13,7 @@ const initialState = {
   isLoading: false,
   error: false,
   mapboxResults: [],
+  resultsQuery: "",
 };
 
 const actionTypes = {
@@ -24,13 +25,14 @@ const actionTypes = {
 function reducer(state = initialState, action) {
   switch (action.type) {
     case actionTypes.FETCH_REQUEST:
-      return { ...state, isLoading: true };
+      return { ...state, isLoading: true, resultsQuery: action.query };
     case actionTypes.FETCH_SUCCESS:
       return {
         ...state,
         error: false,
         isLoading: false,
         mapboxResults: action.results,
+        resultsQuery: action.query,
       };
     case actionTypes.FETCH_FAILURE:
       console.error(action.error);
@@ -41,35 +43,112 @@ function reducer(state = initialState, action) {
 }
 
 export function useMapboxGeocoder() {
-  const [{ isLoading, error, mapboxResults }, dispatch] = useReducer(
-    reducer,
-    initialState
-  );
+  const [{ isLoading, error, mapboxResults, resultsQuery }, dispatch] =
+    useReducer(reducer, initialState);
+  const latestQueryRef = useRef("");
+
+  const performFetch = useCallback(async (searchString) => {
+    const bbox = DEFAULT_VIEWPORTS[TENANT_ID].bbox;
+    const mapboxUrl = `${baseUrl}/${searchString}.json?bbox=${bbox}&access_token=${MAPBOX_ACCESS_TOKEN}`;
+
+    try {
+      const response = await axios.get(mapboxUrl);
+      const results = response.data.features;
+
+      if (latestQueryRef.current === searchString) {
+        dispatch({
+          type: actionTypes.FETCH_SUCCESS,
+          results,
+          query: searchString,
+        });
+      }
+
+      return results;
+    } catch (error) {
+      if (latestQueryRef.current === searchString) {
+        dispatch({ type: actionTypes.FETCH_FAILURE, error });
+      }
+      return [];
+    }
+  }, []);
 
   const debouncedFetch = useCallback(
     debounce(
       async (searchString) => {
-        const bbox = DEFAULT_VIEWPORTS[TENANT_ID].bbox;
-        const mapboxUrl = `${baseUrl}/${searchString}.json?bbox=${bbox}&access_token=${MAPBOX_ACCESS_TOKEN}`;
-
-        try {
-          const response = await axios.get(mapboxUrl);
-          dispatch({
-            type: actionTypes.FETCH_SUCCESS,
-            results: response.data.features,
-          });
-        } catch (error) {
-          dispatch({ type: actionTypes.FETCH_FAILURE, error });
-        }
+        await performFetch(searchString);
       },
       { wait: 300 }
     ),
-    []
+    [performFetch]
   );
-  const fetchMapboxResults = useCallback((searchString) => {
-    dispatch({ type: actionTypes.FETCH_REQUEST });
-    debouncedFetch(searchString);
-  }, []);
 
-  return { error, isLoading, mapboxResults, fetchMapboxResults };
+  const clearResults = useCallback(() => {
+    debouncedFetch.cancel?.();
+    latestQueryRef.current = "";
+    dispatch({
+      type: actionTypes.FETCH_SUCCESS,
+      results: [],
+      query: "",
+    });
+  }, [debouncedFetch]);
+
+  const searchMapboxResults = useCallback(
+    (searchString) => {
+      const normalizedSearchString = searchString.trim();
+      latestQueryRef.current = normalizedSearchString;
+
+      if (!normalizedSearchString) {
+        clearResults();
+        return;
+      }
+
+      dispatch({
+        type: actionTypes.FETCH_REQUEST,
+        query: normalizedSearchString,
+      });
+      debouncedFetch(normalizedSearchString);
+    },
+    [clearResults, debouncedFetch]
+  );
+
+  const ensureMapboxResults = useCallback(
+    async (searchString) => {
+      const normalizedSearchString = searchString.trim();
+
+      if (!normalizedSearchString) {
+        clearResults();
+        return [];
+      }
+
+      if (!isLoading && resultsQuery === normalizedSearchString) {
+        return mapboxResults;
+      }
+
+      latestQueryRef.current = normalizedSearchString;
+      debouncedFetch.cancel?.();
+      dispatch({
+        type: actionTypes.FETCH_REQUEST,
+        query: normalizedSearchString,
+      });
+
+      return performFetch(normalizedSearchString);
+    },
+    [
+      clearResults,
+      debouncedFetch,
+      isLoading,
+      mapboxResults,
+      performFetch,
+      resultsQuery,
+    ]
+  );
+
+  return {
+    error,
+    isLoading,
+    mapboxResults,
+    resultsQuery,
+    searchMapboxResults,
+    ensureMapboxResults,
+  };
 }


### PR DESCRIPTION
 ## Summary

  Fix the search dropdown race condition where pressing Enter quickly after typing a zip code could select a stale organization instead of the correct address.

  ## Problem

  The dropdown mixed two different states:

  - the current input text
  - the last rendered autocomplete results/highlighted option

  When a user typed a zip code like 90011 and pressed Enter quickly, the debounced address lookup could still be behind. In that window, the component could use a stale highlighted option from the previous result, which sometimes caused it to navigate to the first organization instead of the first address.

  ## Solution

  Move result-freshness handling into the geocoder hook and make the dropdown use that API.

  Changes made:

  - useMapboxGeocoder now tracks which query the current Mapbox results belong to with resultsQuery
  - the hook ignores stale async responses so older searches cannot overwrite newer ones
  - the hook now exposes:
      - searchMapboxResults for normal debounced typing
      - ensureMapboxResults for resolving results for the current input on Enter
  - AddressDropDown now clears any stale highlighted option when the input changes
  - on Enter, the dropdown only trusts the highlighted Mapbox address if the rendered results already match the current input, otherwise it asks the hook for current results and selects the first address


  ## Test

npx playwright test

  Manual verification:

  - type a zip code such as 90011
  - press Enter normally
  - press Enter very quickly after typing

  Expected result in both cases:

  - navigation uses the first address result for the current zip code
  - it no longer falls through to the first organization due to stale highlighted results
  
  Closes #2598 