### PR TITLE
update twitter to x in stakeholder

### DIFF
--- a/server/migrations/1776360483357_update-twitter-urls-2172.js
+++ b/server/migrations/1776360483357_update-twitter-urls-2172.js
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.sql(`
+    UPDATE stakeholder
+    SET twitter = REPLACE(twitter, 'twitter.com', 'x.com')
+    WHERE twitter ILIKE '%twitter.com%';
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`
+    UPDATE stakeholder
+    SET twitter = REPLACE(twitter, 'x.com', 'twitter.com')
+    WHERE twitter ILIKE '%x.com%';
+  `);
+};


### PR DESCRIPTION
Resolves #2172 

- Updates Twitter URLs in the stakeholder table to use x.com by replacing. Includes a rollback migration to revert the change if needed.

