### PR TITLE
2695 Add pending suggestions to top of org edit page

### DIFF
--- a/client/src/components/Admin/OrganizationEdit.tsx
+++ b/client/src/components/Admin/OrganizationEdit.tsx
@@ -1031,7 +1031,7 @@ const OrganizationEdit = () => {
                   suggestions={stakeholderSuggestions}
                   editedSuggestions={editedSuggestions}
                   onEdit={handleSuggestionEdit}
-                  showNewOnly={true}
+                  showOpenOnly={true}
                 />
                 <Stack direction="row" justifyContent="space-between">
                   <Typography component="h1" variant="h5">

--- a/client/src/components/Admin/OrganizationEdit/SuggestionHistory.tsx
+++ b/client/src/components/Admin/OrganizationEdit/SuggestionHistory.tsx
@@ -18,7 +18,7 @@ interface SuggestionHistoryProps {
   suggestions?: Suggestion[];
   editedSuggestions: EditedSuggestions;
   onEdit?: (id: number, changes: Partial<Suggestion>) => void;
-  showNewOnly?: boolean;
+  showOpenOnly?: boolean;
   confirmationErrors?: Record<string, string>;
 }
 
@@ -29,12 +29,14 @@ function formatDate(dateStr?: string) {
   return date.toISOString().slice(0, 10);
 }
 
+const OPEN_SUGGESTION_STATUS_IDS = [1, 2];
+
 export default function SuggestionHistory({
   tabPage = 0,
   suggestions = [],
   editedSuggestions,
   onEdit,
-  showNewOnly = false,
+  showOpenOnly = false,
 }: SuggestionHistoryProps) {
   const handleInputChange = (
     id: number,
@@ -46,111 +48,115 @@ export default function SuggestionHistory({
 
   const safeSuggestions = Array.isArray(suggestions) ? suggestions : [];
 
-  const filteredSuggestions = showNewOnly
+  const filteredSuggestions = showOpenOnly
     ? safeSuggestions.filter(
-        (suggestion) => suggestion.suggestionStatusId === 1
+        (suggestion) =>
+          suggestion.suggestionStatusId !== undefined &&
+          OPEN_SUGGESTION_STATUS_IDS.includes(suggestion.suggestionStatusId)
       )
     : safeSuggestions;
 
-  if (showNewOnly && filteredSuggestions.length === 0) return null;
+  if (showOpenOnly && filteredSuggestions.length === 0) return null;
+
+  const content = (
+    <Stack spacing={3}>
+      {filteredSuggestions.map((suggestion) => (
+        <Paper
+          key={suggestion.id}
+          sx={(theme: any) => ({
+            backgroundColor: theme.palette.primary.extralight,
+            px: 4,
+            py: 2,
+          })}
+        >
+          <Typography variant="subtitle1" gutterBottom>
+            Suggestion ({formatDate(suggestion.createdDate)}
+            {suggestion.tipsterName && <> | {suggestion.tipsterName}</>}
+            {suggestion.tipsterEmail && <> | {suggestion.tipsterEmail}</>}
+            {suggestion.tipsterPhone && <> | {suggestion.tipsterPhone}</>})
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 1 }}>
+            {suggestion.notes}
+          </Typography>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={2}
+            alignItems="center"
+          >
+            <Stack
+              direction="row"
+              spacing={2}
+              sx={{ mb: 1, width: "100%" }}
+              flex={1}
+            >
+              <InputLabel
+                htmlFor={`suggestionAdminNotes-${suggestion.id}`}
+                sx={{ minWidth: "fit-content" }}
+              >
+                Note:
+              </InputLabel>
+              <Textarea
+                placeholder="Admin Notes"
+                id={`suggestionAdminNotes-${suggestion.id}`}
+                name={`suggestionAdminNotes-${suggestion.id}`}
+                fullWidth
+                value={
+                  editedSuggestions[suggestion.id]?.adminNotes ??
+                  suggestion.adminNotes ??
+                  ""
+                }
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  handleInputChange(suggestion.id, "adminNotes", e.target.value)
+                }
+              />
+            </Stack>
+            <Box sx={{ minWidth: 200 }}>
+              <RadioGroup
+                value={
+                  editedSuggestions[suggestion.id]?.suggestionStatusId ??
+                  suggestion.suggestionStatusId ??
+                  ""
+                }
+                onChange={(e) =>
+                  handleInputChange(
+                    suggestion.id,
+                    "suggestionStatusId",
+                    Number(e.target.value)
+                  )
+                }
+              >
+                {FILTERS.map((status: { id: number; name: string }) => (
+                  <FormControlLabel
+                    key={status.id}
+                    value={status.id}
+                    control={
+                      <Radio
+                        sx={(theme) => ({
+                          "&.Mui-checked": {
+                            color: theme.palette.secondary.main,
+                          },
+                        })}
+                      />
+                    }
+                    label={status.name}
+                  />
+                ))}
+              </RadioGroup>
+            </Box>
+          </Stack>
+        </Paper>
+      ))}
+      {filteredSuggestions.length === 0 && (
+        <Typography>No suggestions found.</Typography>
+      )}
+    </Stack>
+  );
+
+  if (showOpenOnly) return <Box sx={{ m: 3 }}>{content}</Box>;
 
   return (
-    <TabPanel value={tabPage} index={showNewOnly ? -1 : 6}>
-      <Stack spacing={3}>
-        {filteredSuggestions.map((suggestion) => (
-          <Paper
-            key={suggestion.id}
-            sx={(theme: any) => ({
-              backgroundColor: theme.palette.primary.extralight,
-              px: 4,
-              py: 2,
-            })}
-          >
-            <Typography variant="subtitle1" gutterBottom>
-              Suggestion ({formatDate(suggestion.createdDate)}
-              {suggestion.tipsterName && <> | {suggestion.tipsterName}</>}
-              {suggestion.tipsterEmail && <> | {suggestion.tipsterEmail}</>}
-              {suggestion.tipsterPhone && <> | {suggestion.tipsterPhone}</>})
-            </Typography>
-            <Typography variant="body1" sx={{ mb: 1 }}>
-              {suggestion.notes}
-            </Typography>
-            <Stack
-              direction={{ xs: "column", sm: "row" }}
-              spacing={2}
-              alignItems="center"
-            >
-              <Stack
-                direction="row"
-                spacing={2}
-                sx={{ mb: 1, width: "100%" }}
-                flex={1}
-              >
-                <InputLabel
-                  htmlFor={`suggestionAdminNotes-${suggestion.id}`}
-                  sx={{ minWidth: "fit-content" }}
-                >
-                  Note:
-                </InputLabel>
-                <Textarea
-                  placeholder="Admin Notes"
-                  id={`suggestionAdminNotes-${suggestion.id}`}
-                  name={`suggestionAdminNotes-${suggestion.id}`}
-                  fullWidth
-                  value={
-                    editedSuggestions[suggestion.id]?.adminNotes ??
-                    suggestion.adminNotes ??
-                    ""
-                  }
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleInputChange(
-                      suggestion.id,
-                      "adminNotes",
-                      e.target.value
-                    )
-                  }
-                />
-              </Stack>
-              <Box sx={{ minWidth: 200 }}>
-                <RadioGroup
-                  value={
-                    editedSuggestions[suggestion.id]?.suggestionStatusId ??
-                    suggestion.suggestionStatusId ??
-                    ""
-                  }
-                  onChange={(e) =>
-                    handleInputChange(
-                      suggestion.id,
-                      "suggestionStatusId",
-                      Number(e.target.value)
-                    )
-                  }
-                >
-                  {FILTERS.map((status: { id: number; name: string }) => (
-                    <FormControlLabel
-                      key={status.id}
-                      value={status.id}
-                      control={
-                        <Radio
-                          sx={(theme) => ({
-                            "&.Mui-checked": {
-                              color: theme.palette.secondary.main,
-                            },
-                          })}
-                        />
-                      }
-                      label={status.name}
-                    />
-                  ))}
-                </RadioGroup>
-              </Box>
-            </Stack>
-          </Paper>
-        ))}
-        {filteredSuggestions.length === 0 && (
-          <Typography>No suggestions found.</Typography>
-        )}
-      </Stack>
+    <TabPanel value={tabPage} index={6}>
+      {content}
     </TabPanel>
   );
 }


### PR DESCRIPTION
- Closes https://github.com/hackforla/food-oasis/issues/2695

All open suggestions/corrections (New and Pending) must appear pinned at the top of the organization details page.

Open items must also appear in the Suggestion History tab.

Only closed suggestions/corrections (Incorrect, Confirmed) should appear exclusively in Suggestion History.

<img width="1009" height="938" alt="Screenshot 2026-06-15 at 11 11 24 PM" src="https://github.com/user-attachments/assets/3e0ada10-565f-48bb-94e9-a0b74300db4b" />
