### PR TITLE
Add "Date Created" and "Number of Days Open" to Suggestions Admin

### DIFF
--- a/client/src/components/Admin/Suggestions.tsx
+++ b/client/src/components/Admin/Suggestions.tsx
@@ -37,6 +37,7 @@ import {
   TableRow,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material/Select";
+import dayjs from "dayjs";
 import { Formik } from "formik";
 import { useSuggestions } from "hooks/useSuggestions";
 import { useEffect, useState } from "react";
@@ -49,6 +50,7 @@ import Textarea from "./ui/Textarea";
 interface Filter {
   id: number;
   name: string;
+  isClosed?: boolean;
 }
 
 interface AdminSuggestion {
@@ -68,6 +70,8 @@ interface AdminSuggestion {
   tipsterName?: string;
   tipsterEmail?: string;
   tipsterPhone?: string;
+  createdDate?: string;
+  closedDate?: string | null;
 }
 
 interface SuggestionFormValues {
@@ -89,12 +93,38 @@ const columns: Column[] = [
   { id: "formType", label: "Type", minWidth: 10 },
 ];
 
+const LEADING_COLUMNS = columns.slice(0, 2);
+const TRAILING_COLUMNS = columns.slice(2);
+
 export const FILTERS: Filter[] = [
   { id: 1, name: "New" },
   { id: 2, name: "Pending" },
-  { id: 3, name: "Incorrect" },
-  { id: 4, name: "Confirmed" },
+  { id: 3, name: "Incorrect", isClosed: true },
+  { id: 4, name: "Confirmed", isClosed: true },
 ];
+
+const CLOSED_STATUS_IDS = FILTERS.filter((f) => f.isClosed).map((f) => f.id);
+
+function getDaysOpen(s: {
+  createdDate?: string;
+  closedDate?: string | null;
+  suggestionStatusId?: number;
+}): number | null {
+  if (!s.createdDate) return null;
+  const created = dayjs(s.createdDate);
+  const isClosed = CLOSED_STATUS_IDS.includes(Number(s.suggestionStatusId));
+  const end = isClosed
+    ? s.closedDate
+      ? dayjs(s.closedDate)
+      : null // closed but no stored close date (legacy row)
+    : dayjs();
+  if (!end) return null;
+  return Math.max(0, end.diff(created, "day"));
+}
+
+function formatDate(value?: string): string {
+  return value ? dayjs(value).format("MM/DD/YYYY") : "n/a";
+}
 
 function getModalStyle() {
   const top = 50;
@@ -126,6 +156,7 @@ function Suggestions() {
   };
   const isMobile = getIsMobile();
   const location = useLocation();
+  const daysOpen = activeOrg ? getDaysOpen(activeOrg) : null;
 
   useEffect(() => {
     if (data) {
@@ -241,7 +272,20 @@ function Suggestions() {
           <Table stickyHeader aria-label="sticky table">
             <TableHead>
               <TableRow>
-                {columns.map((column) => (
+                {LEADING_COLUMNS.map((column) => (
+                  <TableCell
+                    key={column.id}
+                    align={column.align}
+                    style={{ minWidth: column.minWidth }}
+                  >
+                    {column.label}
+                  </TableCell>
+                ))}
+                <TableCell style={{ minWidth: 110 }}>Date Created</TableCell>
+                <TableCell style={{ minWidth: 110 }}>
+                  Number of Days Open
+                </TableCell>
+                {TRAILING_COLUMNS.map((column) => (
                   <TableCell
                     key={column.id}
                     align={column.align}
@@ -256,6 +300,12 @@ function Suggestions() {
               {suggestions
                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                 .map((suggestion) => {
+                  const handleRowClick = () => {
+                    const org = suggestions.find(
+                      (org) => suggestion.id === org.id
+                    );
+                    setActiveOrg(org || null);
+                  };
                   return (
                     <TableRow
                       hover
@@ -264,18 +314,31 @@ function Suggestions() {
                       key={suggestion.id}
                       selected={suggestion.id === activeOrg?.id}
                     >
-                      {columns.map((column) => {
+                      {LEADING_COLUMNS.map((column) => {
                         const value = suggestion[column.id];
                         return (
                           <TableCell
                             key={column.id}
                             align={column.align}
-                            onClick={() => {
-                              const org = suggestions.find(
-                                (org) => suggestion.id === org.id
-                              );
-                              setActiveOrg(org || null);
-                            }}
+                            onClick={handleRowClick}
+                          >
+                            {value}
+                          </TableCell>
+                        );
+                      })}
+                      <TableCell onClick={handleRowClick}>
+                        {formatDate(suggestion.createdDate)}
+                      </TableCell>
+                      <TableCell onClick={handleRowClick}>
+                        {getDaysOpen(suggestion) ?? "n/a"}
+                      </TableCell>
+                      {TRAILING_COLUMNS.map((column) => {
+                        const value = suggestion[column.id];
+                        return (
+                          <TableCell
+                            key={column.id}
+                            align={column.align}
+                            onClick={handleRowClick}
                           >
                             {column.label === "Status" ? (
                               <Chip
@@ -444,6 +507,18 @@ function Suggestions() {
                         />
                       </div>
                       <List>
+                        <DisplayText
+                          label="Date Created"
+                          value={formatDate(activeOrg.createdDate)}
+                          icon={<AccessTimeIcon />}
+                        />
+                        <Divider variant="inset" component="li" />
+                        <DisplayText
+                          label="Number of Days Open"
+                          value={daysOpen === null ? "n/a" : String(daysOpen)}
+                          icon={<AccessTimeIcon />}
+                        />
+                        <Divider variant="inset" component="li" />
                         <DisplayText
                           label="Tipster Notes"
                           value={activeOrg.notes}

--- a/client/src/types/Organization.ts
+++ b/client/src/types/Organization.ts
@@ -101,6 +101,7 @@ export interface OrganizationFormValues {
 export interface Suggestion {
   id: number;
   createdDate?: string;
+  closedDate?: string | null;
   tipsterName?: string;
   tipsterEmail?: string;
   tipsterPhone?: string;

--- a/server/app/services/suggestion-service.ts
+++ b/server/app/services/suggestion-service.ts
@@ -1,7 +1,12 @@
 import db from "./db";
 import camelcaseKeys from "camelcase-keys";
-import { Suggestion } from "../../types/suggestion-types";
+import { Suggestion, SuggestionStatusId } from "../../types/suggestion-types";
 import { SuggestionPostFields } from "../validation-schema/suggestion-schema";
+
+const CLOSED_STATUS_IDS = [
+  SuggestionStatusId.Incorrect,
+  SuggestionStatusId.Confirmed,
+];
 
 const selectAll = async (params: {
   statusIds: string[];
@@ -15,7 +20,8 @@ const selectAll = async (params: {
     select id, name, address_1, address_2, city, state, zip,
     phone, email, notes,
     tipster_name, tipster_phone, tipster_email,
-    hours, category, suggestion_status_id, admin_notes, tenant_id, form_type
+    hours, category, suggestion_status_id, admin_notes, tenant_id, form_type,
+    created_date, closed_date
     from suggestion
     where suggestion_status_id = any ($<statusIds>)
     and tenant_id = $<tenantId>
@@ -36,7 +42,8 @@ const selectById = async (suggestionId: string): Promise<Suggestion> => {
     select id, name, address_1, address_2, city, state, zip,
     phone, email, notes,
     tipster_name, tipster_phone, tipster_email,
-    hours, category, suggestion_status_id, admin_notes, tenant_id, form_type
+    hours, category, suggestion_status_id, admin_notes, tenant_id, form_type,
+    created_date, closed_date
     from suggestion where id = $<id>`;
 
   const row: Suggestion = await db.one(sql, { id });
@@ -90,6 +97,14 @@ const update = async (id: string, model: Partial<Suggestion>) => {
   if (model.suggestionStatusId !== undefined) {
     fields.push("suggestion_status_id = $<suggestionStatusId>");
     params.suggestionStatusId = model.suggestionStatusId;
+
+    // CLOSED statuses: stamp once; keep existing if already closed.
+    // OPEN statuses: clear the close date.
+    if (CLOSED_STATUS_IDS.includes(Number(model.suggestionStatusId))) {
+      fields.push("closed_date = COALESCE(closed_date, CURRENT_TIMESTAMP)");
+    } else {
+      fields.push("closed_date = NULL");
+    }
   }
 
   if (fields.length === 0) return;

--- a/server/app/validation-schema/suggestion-schema.ts
+++ b/server/app/validation-schema/suggestion-schema.ts
@@ -3,7 +3,12 @@ import { Suggestion } from "../../types/suggestion-types";
 
 export type SuggestionPostFields = Omit<
   Suggestion,
-  "id" | "suggestionStatusId" | "stakeholderId" | "adminNotes"
+  | "id"
+  | "suggestionStatusId"
+  | "stakeholderId"
+  | "adminNotes"
+  | "createdDate"
+  | "closedDate"
 >;
 
 export const suggestionPostRequestSchema: JSONSchemaType<SuggestionPostFields> =
@@ -158,6 +163,8 @@ export const suggestionPutRequestSchema: JSONSchemaType<Suggestion> = {
         },
       ],
     },
+    createdDate: { type: "string", nullable: true },
+    closedDate: { type: "string", nullable: true },
   },
   additionalProperties: false,
 };

--- a/server/types/suggestion-types.ts
+++ b/server/types/suggestion-types.ts
@@ -19,9 +19,18 @@ export interface Suggestion {
   stakeholderId: number;
   tenantId: number;
   formType: FormTypeEnum;
+  createdDate?: string;
+  closedDate?: string | null;
 }
 
 export enum FormTypeEnum {
   Suggestion = "suggestion",
   Correction = "correction",
+}
+
+export enum SuggestionStatusId {
+  New = 1,
+  Pending = 2,
+  Incorrect = 3,
+  Confirmed = 4,
 }


### PR DESCRIPTION
- Closes #2580 

<img width="1301" height="739" alt="image" src="https://github.com/user-attachments/assets/24b978f4-e75b-4261-829a-a61a7bed142a" />

<img width="1576" height="1240" alt="image" src="https://github.com/user-attachments/assets/646b2044-3873-4a5c-a3f3-e1f5270f58d5" />


### Summary
Adds two read-only fields to the Suggestions Administration table and details modal so admins can see when a correction/suggestion was submitted and how long it's been open.

- **Date Created**: the existing `created_date`, now exposed via the API (it was already in the DB but never selected for this view).
- **Number of Days Open**: computed client-side on load — `today − createdDate` for OPEN statuses (New, Pending), `closedDate − createdDate` for CLOSED statuses (Incorrect, Confirmed), frozen once closed.

### Why server changes were needed
The ticket assumed this was front-end only, but two gaps required backend work:
- `selectAll`/`selectById` in `suggestion-service.ts` didn't select `created_date` for this view.
- There was no `closed_date` column, so the CLOSED-status interval couldn't be computed at all.

### Changes
- **Migration**: new nullable `closed_date` timestamp column on `suggestion`.
- **Server**: `selectAll`/`selectById` now return `created_date`/`closed_date`; `update` stamps `closed_date` when status moves to Incorrect/Confirmed (idempotent — re-saving a closed record doesn't reset the timestamp) and clears it when moved back to New/Pending. Added the fields to `Suggestion`/`SuggestionPostFields` types and the PUT validation schema (POST schema explicitly excludes them — they're server-derived, not client-supplied).
- **Client**: added `closedDate` to the `Suggestion` and `AdminSuggestion` types; added a `getDaysOpen`/`formatDate` helper pair; inserted the two columns between Notes and Status in the table, and the two fields in the modal's Admin Notes section before Tipster details.

### Notes
- Historically-closed rows have no `closed_date` and will show `n/a` for days-open until an admin re-saves them with a closed status (not backfilled — accepted tradeoff).
- Fixed a latent falsy-value bug in the shared `DisplayText` component's call site: a same-day suggestion has `daysOpen === 0`, which is falsy, so it's passed as a string to avoid being swallowed into `"n/a"`.
