### PR TITLE
Update suggestions and corrections admin labels

### DIFF
--- a/client/src/components/Admin/Suggestions.tsx
+++ b/client/src/components/Admin/Suggestions.tsx
@@ -35,6 +35,7 @@ import {
   TablePagination,
   TablePaginationOwnProps,
   TableRow,
+  Typography,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material/Select";
 import { Formik } from "formik";
@@ -205,7 +206,14 @@ function Suggestions() {
           justifyContent: "space-between",
         })}
       >
-        <h2>Suggestions Administration</h2>
+        <Box>
+          <Typography component="h1" variant="h4">
+            Suggestions &amp; Corrections Administration
+          </Typography>
+          <Typography variant="subtitle1">
+            Suggested new listings and Corrections to existing listings
+          </Typography>
+        </Box>
         <FormControl
           sx={(theme) => ({
             margin: theme.spacing(1),

--- a/client/src/components/Layout/Menu.tsx
+++ b/client/src/components/Layout/Menu.tsx
@@ -105,7 +105,7 @@ export default function Menu(): React.ReactElement {
                 <MenuItemLink
                   key="suggestions"
                   to="/admin/suggestions"
-                  text="Suggestions"
+                  text="Suggestions & Corrections"
                 />
                 <MenuItemLink
                   key="logins"


### PR DESCRIPTION
## Description

- Renames the page heading to “Suggestions & Corrections Administration”
- Adds a subtitle describing the page
- Updates the admin navigation label to “Suggestions & Corrections”

## Testing

- Confirmed the updated heading and subtitle display correctly
- Confirmed the navigation label was updated
- Confirmed no references to “Suggestions Administration” remain

Closes #2587