### PR TITLE
Fixes Phone/Ext fields and Confirm checkbox alignment on validation error

### DIFF
--- a/client/src/components/Admin/OrganizationEdit/Identification.tsx
+++ b/client/src/components/Admin/OrganizationEdit/Identification.tsx
@@ -56,7 +56,8 @@ interface GeocodeResult {
   };
 }
 
-interface IdentificationProps extends OrganizationSectionWithSetFieldValueProps {
+interface IdentificationProps
+  extends OrganizationSectionWithSetFieldValueProps {
   setFieldTouched: (
     field: string,
     isTouched?: boolean,
@@ -196,7 +197,7 @@ export default function Identification({
               <Stack
                 direction={{ xs: "column", sm: "row" }}
                 spacing={{ xs: 1, sm: 2, md: 4 }}
-                alignItems="flex-end"
+                alignItems="flex-start"
               >
                 <Box sx={{ width: { xs: "100%", sm: "auto" } }}>
                   <Label
@@ -232,7 +233,12 @@ export default function Identification({
                   />
                 </Box>
 
-                <Box sx={confirmationErrorSx("confirmedPhone")}>
+                <Box
+                  sx={[
+                    { pt: { sm: "40px" } },
+                    confirmationErrorSx("confirmedPhone"),
+                  ]}
+                >
                   <FormControlLabel
                     componentsProps={{
                       typography: {


### PR DESCRIPTION
Closes #2850 

Changed the Phone/Ext/Confirm row's alignItems from flex-end to flex-start 
- Previously, when the Phone input displayed a validation error, it would shift upwards while the rest of the boxes stayed at the bottom. 
- Added padding to Confirm Checkbox so its vertically centered to other fields

Screenshot:
https://github.com/user-attachments/assets/642272f2-fb64-4a37-9b61-6506542aff92

