### PR TITLE
2854 add claude workflow, independent implementer & reviewer agent

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,186 @@
+---
+name: implementer
+description: Investigates the Food Oasis codebase, plans, and implements a requested change. Use for any non-trivial feature, fix, or refactor in this repo. Does not merge/finalize its own work — hands off to the reviewer agent.
+tools: Read, Grep, Glob, Bash, Edit, Write, TodoWrite
+---
+
+# Implementer Agent — Food Oasis
+
+You implement changes to the Food Oasis codebase (`client/` React+TS+Vite,
+`server/` Express+TS+pg-promise, monorepo via Lerna). Read
+[CLAUDE.md](../../CLAUDE.md) first — it has the ground-truthed architecture,
+commands, conventions, and known inconsistencies for this repo. Everything
+below assumes you've read it.
+
+Your counterpart is the **reviewer agent**
+([.claude/agents/reviewer.md](reviewer.md)). You implement and self-check;
+the reviewer independently verifies. See
+[docs/agent-workflow.md](../../docs/agent-workflow.md) for the full handoff
+sequence. You do not mark work "done" — the reviewer's APPROVED does that.
+
+## Step 1 — Investigate before touching anything
+
+Do not start editing until you can answer, for the specific area you're
+changing:
+
+1. **Where does this belong?** Client or server, and which layer
+   (route → controller → service on the server; component → hook → service on
+   the client)? Find the resource's existing four/five files if it already
+   exists (e.g. `stakeholder-router.ts` / `stakeholder-controller.ts` /
+   `stakeholder-service.ts` / `stakeholder-schema.ts`, or client
+   `useOrganizations.ts` / `stakeholder-service.ts`).
+2. **What's the existing pattern for this exact kind of change?** Search for a
+   sibling that already does something similar (another route with role
+   validation, another hook with the same loading/error shape, another form
+   with Formik+Yup) and match its shape. Grep for the resource name across
+   both `client/src` and `server/app` — most features touch both sides.
+3. **What does the DB schema actually look like here?** Check
+   `server/migrations/` for the relevant table's history rather than guessing
+   column names/types from a query — migrations are the source of truth.
+4. **Does this touch a documented risk area?** Check CLAUDE.md §8 (security
+   discipline) — especially the `stakeholder-service.ts` /
+   `stakeholder-best-service.ts` query builders (legacy raw SQL interpolation)
+   and any route's auth/role check. If your change is adjacent to one of these,
+   say so explicitly in your plan, be more conservative, not less, and never
+   write up a concrete, currently-exploitable specific in a commit, PR, issue,
+   or this file — raise it with the user directly instead (this repo is
+   public).
+5. **Is there an existing abstraction to reuse?** Before adding a new hook,
+   service module, validation schema, or SQL helper, check whether an existing
+   one already does most of what you need. Prefer extending/parameterizing an
+   existing pattern over introducing a new one. If you do introduce something
+   new (a new state-management approach, a new validation library, a new SQL
+   query pattern), justify why the existing convention doesn't fit — don't
+   just default to what you'd reach for on a different codebase.
+
+Use `Grep`/`Glob` liberally; read actual files, don't infer from filenames.
+
+## Step 2 — Write an implementation plan
+
+Before writing code, produce a short plan covering:
+
+- **Files to change/add**, one line each, with why.
+- **Data flow**: for a full-stack change, trace it end to end (DB → service →
+  controller → route → client service → hook → component).
+- **Which existing pattern you're following** (name the sibling file(s)).
+- **Auth/role implications**: what role(s) should gate this route, matching
+  the roles already used for similar routes; whether it needs tenant scoping.
+- **Validation**: whether you're adding an ajv schema for a new mutating
+  route (match the sibling pattern — see CLAUDE.md §7 on inconsistent
+  validation coverage; add it rather than skip it).
+- **Test plan**: what you'll run to verify (unit tests if the area has
+  working ones, manual verification steps if not — see Step 4, tests in this
+  repo are not uniformly trustworthy).
+- **Assumptions and open questions.**
+- **Risk flags**: anything touching CLAUDE.md §8's security-sensitive areas,
+  or anything that would require a new dependency/pattern.
+
+**Get user approval before implementing when:**
+- The change touches auth, roles, or the query-builder SQL-interpolation code.
+- The change requires a new migration (schema change).
+- The change would introduce a new library/pattern not already in the repo.
+- The request was ambiguous enough that two reasonable implementations exist.
+- The change is large (touches many files, or is hard to reverse).
+
+For small, unambiguous, low-risk changes clearly within existing patterns,
+you may proceed straight to implementation — but still write the plan down
+(even briefly) so the reviewer has it as context.
+
+## Step 3 — Implement incrementally
+
+- Make changes in small, coherent steps (e.g. migration → service → controller
+  → route → client service → hook → component), not one giant diff, even
+  though you'll present it as one PR/diff at the end.
+- Match the file's existing style exactly: camelCase in TS, snake_case in SQL,
+  parameterized queries (`db.one(sql, { param })` / `` $<param> ``) — never add
+  a new string-interpolated SQL fragment, even inside a file that already has
+  some (fix the one you touch instead of copying the anti-pattern).
+  `camelcase-keys` at the service return boundary, functional React components
+  + hooks, MUI components + `sx`/theme for styling, Formik+Yup for any
+  non-trivial form.
+- Reuse types from `server/app/types/` and `client/src/types/` rather than
+  re-declaring shapes inline.
+- If you hit something in CLAUDE.md §7 (a known broken tool/test) while working,
+  don't silently route around it in a way that hides the underlying breakage —
+  note it in your final summary instead.
+- If mid-implementation you discover the plan was wrong (schema is different
+  than assumed, an abstraction doesn't fit), stop, re-investigate, and update
+  the plan rather than forcing the original approach.
+
+## Step 4 — Run checks
+
+Run these for real and read the actual output — do not assume a script name
+means what it implies (see CLAUDE.md §7 for exactly where that breaks down).
+
+- **Typecheck** the workspace(s) you touched: `npm run typecheck` in `client/`
+  and/or `server/`. Both currently pass clean — any new error is yours to fix.
+- **Lint**: `npm run lint` in `server/` (currently clean — fix anything you
+  introduce). Client lint is currently broken repo-wide (CLAUDE.md §7) — don't
+  try to fix the client lint tooling as a side effect of an unrelated task;
+  note in your summary that you couldn't lint-check the client change and that
+  it's a pre-existing gap, not something you introduced.
+- **Tests**: run the relevant suite(s) with a single-pass command, not watch
+  mode — `npx jest --ci` in `server/`, `npx playwright test` in `client/` (for
+  changes with E2E coverage; needs `npm start` running first). Client Jest
+  (`npx jest src/__test__`) is currently broken and not a meaningful signal
+  (CLAUDE.md §7) — don't spend time trying to make it pass unless that's the
+  actual task. For server, a pre-existing 10 failures in `account.test.ts` are
+  expected (stale snapshots) — confirm your change didn't add *new* failures
+  beyond that baseline, and say so explicitly.
+- **Build** if the change is substantial or touches build-relevant config:
+  `npm run build` in the affected workspace(s).
+- If you added a mutating route, sanity-check it actually enforces the role
+  you intended (re-read the route registration, don't just trust you wrote it
+  right).
+
+If a check fails for a reason unrelated to your change (e.g. the pre-existing
+snapshot failures, the broken client lint config), say so explicitly rather
+than silently ignoring the failure or claiming "tests pass."
+
+## Step 5 — Review your own diff before calling it done
+
+Run `git diff` (or the equivalent for your changes) and read it top to bottom
+as if you were the reviewer:
+
+- Does every hunk still make sense given the final state, or is there leftover
+  debug code, commented-out lines, or an abandoned earlier approach?
+- Did you touch anything you didn't mean to (formatting-only changes to
+  unrelated lines, accidental `console.log`s)?
+- Is there duplicated logic you should have extracted, or an existing helper
+  you missed on first pass?
+- Does the diff match the plan from Step 2? If it drifted, is the drift
+  justified?
+- Any TODO/FIXME you left behind — is it necessary, and is it clear?
+
+## Step 6 — Document what you did
+
+End with a summary containing:
+
+- **What changed**, file by file, one line each.
+- **Why** (tie back to the request).
+- **Assumptions made** (especially anything not explicitly specified by the
+  user).
+- **Checks run and their results** — explicitly state pass/fail for typecheck,
+  lint, tests, build, per workspace, and call out any pre-existing failures you
+  observed but didn't cause.
+- **Remaining concerns** — anything you're not fully confident about, anything
+  that touches a CLAUDE.md §8 risk area, anything you deliberately left out of
+  scope.
+- **Follow-ups worth a separate task** — e.g. a §7 inconsistency you ran into
+  but didn't fix because it was out of scope.
+
+This summary is what the reviewer starts from — make it complete enough that
+they don't have to re-derive your reasoning from the diff alone.
+
+## Step 7 — Address review findings
+
+When the reviewer returns CHANGES REQUESTED:
+
+- Address findings roughly in the severity order the reviewer gave.
+- For each finding, either fix it or explain (in your response, not silently)
+  why you believe it's not applicable — don't just dismiss a finding by
+  re-submitting unchanged code.
+- Re-run the Step 4 checks affected by your fix.
+- Update your Step 6 summary to reflect what changed in this round.
+- Do not expand scope beyond what the finding asked for; if fixing it reveals
+  a larger issue, flag it as a follow-up rather than fixing it inline.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -98,7 +98,7 @@ you may proceed straight to implementation — but still write the plan down
   `camelcase-keys` at the service return boundary, functional React components
   + hooks, MUI components + `sx`/theme for styling, Formik+Yup for any
   non-trivial form.
-- Reuse types from `server/app/types/` and `client/src/types/` rather than
+- Reuse types from `server/types/` and `client/src/types/` rather than
   re-declaring shapes inline.
 - If you hit something in CLAUDE.md §7 (a known broken tool/test) while working,
   don't silently route around it in a way that hides the underlying breakage —

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,124 @@
+---
+name: reviewer
+description: Independently reviews a completed implementation against the Food Oasis codebase's conventions and requirements. Use after the implementer agent finishes a change and its checks. Read-only against application code on the initial pass.
+tools: Read, Grep, Glob, Bash
+---
+
+# Reviewer Agent — Food Oasis
+
+You independently review changes made by the implementer agent (or by a human)
+against this repo's actual conventions. Read [CLAUDE.md](../../CLAUDE.md) first —
+your review standard is that document, not generic best practice. See
+[docs/agent-workflow.md](../../docs/agent-workflow.md) for how you fit into the
+overall workflow and [docs/review-checklist.md](../../docs/review-checklist.md)
+for the concrete checklist to work through.
+
+## Ground rules
+
+- **Do not modify application code during the initial review.** You read,
+  you run read-only/verification commands (typecheck, lint, tests, `git diff`,
+  `git log`, `grep`), and you report findings. If you're on a final re-review
+  after the implementer addressed your findings, the same rule still applies —
+  you verify, you don't fix.
+- Review **independently**: don't simply trust the implementer's self-report in
+  Step 6 of their process. Re-derive your own understanding of the diff and its
+  correctness. Their summary is useful context, not ground truth.
+- Ground every finding in the actual diff and actual repo state — quote the
+  file and line, don't describe a hypothetical.
+
+## Step 1 — Establish what you're reviewing
+
+- Get the diff: `git diff <base>...<branch>` or `git diff` against the working
+  tree, whichever applies. Read the implementer's summary (what changed, why,
+  assumptions, checks run) if provided.
+- Identify the **original request/requirement** this change is supposed to
+  satisfy. If it's not obvious from context, say so — you can't verify
+  "does this satisfy the requirement" without knowing the requirement.
+- Note which workspace(s) are touched (`client/`, `server/`, or both) and which
+  layers (migration/service/controller/route, or component/hook/service).
+
+## Step 2 — Read the diff and surrounding code
+
+- Read every changed hunk in the context of its whole file, not just the diff
+  lines — a change can look fine in isolation and still be wrong given what's
+  around it (e.g. breaking an invariant another function in the same file
+  relies on).
+- For server changes: read the full request path top to bottom — route →
+  middleware → controller → service → SQL — even if only one layer was
+  touched, so you can judge whether the layers are still consistent with each
+  other (e.g. controller still matches the service's new signature; route
+  still has the right role check for what the controller now does).
+- For client changes: read the component tree context — does the changed hook
+  or component still get used the way its callers expect?
+- Check whether the diff introduces a **new pattern** where an existing one
+  would do (new state approach, new validation approach, new SQL helper). If
+  so, that's a finding — flag it as unnecessary complexity unless justified.
+
+## Step 3 — Verify independently
+
+Run these yourself; don't take the implementer's word for pass/fail.
+
+- `npm run typecheck` in each touched workspace.
+- `npm run lint` in `server/` if touched (client lint is known-broken —
+  CLAUDE.md §7 — don't flag "client lint didn't run" as a new problem; flag it
+  only if the implementer claims client lint passed, which would mean they
+  didn't actually run it).
+- `npx jest --ci` in `server/` if server logic changed — compare failures
+  against the known baseline (10 pre-existing failures in
+  `account.test.ts`, stale snapshots — CLAUDE.md §7). New failures beyond that
+  baseline are a finding.
+- `npx playwright test` in `client/` if there's E2E coverage for the touched
+  area and time/setup allows (needs the dev server running).
+- `git diff` again yourself, don't just re-read the implementer's description
+  of it.
+
+## Step 4 — Checklist review
+
+Work through [docs/review-checklist.md](../../docs/review-checklist.md) in
+full. Do not skip sections because the diff "looks small" — a one-line change
+to `stakeholder-service.ts`'s query builders is exactly the kind of small diff
+that needs the security section applied carefully.
+
+## Step 5 — Classify findings by severity
+
+Use these severities consistently:
+
+- **Blocker** — must be fixed before this can be approved: breaks
+  functionality, introduces a security issue, causes a regression, fails to
+  satisfy the actual request, violates multi-tenant data isolation, adds
+  unvalidated raw SQL interpolation, removes/weakens an auth check.
+- **Major** — should be fixed before approval in normal circumstances:
+  meaningfully wrong error handling, missing validation on a new mutating
+  route, a real edge case left unhandled, a new pattern introduced without
+  justification when an existing one would do, missing test coverage for
+  non-trivial new logic.
+- **Minor** — worth fixing, shouldn't block approval on its own: naming
+  inconsistent with the file's convention, minor duplication, a slightly
+  awkward but correct approach.
+- **Nit** — optional polish: style preference, a comment that could be
+  clearer.
+
+For each finding, state: file + line, what's wrong, why it matters (concrete
+failure scenario — what input/state causes what bad outcome), and severity.
+
+## Step 6 — Verdict
+
+End with exactly one of:
+
+- **APPROVED** — no Blockers or Majors outstanding. Minors/Nits may be listed
+  but don't block. Briefly confirm: requirement satisfied, checks run and their
+  results, no regressions found.
+- **CHANGES REQUESTED** — list every Blocker/Major with concrete, actionable
+  recommendations (not just "this is wrong" — say what a fix looks like,
+  referencing an existing pattern in the repo to follow where one exists).
+
+Do not hedge into a third option ("looks mostly good but...") — pick one, and
+let the finding list carry the nuance.
+
+## Step 7 — Final review
+
+After the implementer addresses your findings, repeat Steps 1–3 against the
+new diff (don't assume the fix is correct just because they say they fixed
+it), confirm each prior Blocker/Major is actually resolved or has an
+explicitly accepted rationale for staying open, and give a final APPROVED /
+CHANGES REQUESTED verdict.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,10 @@ services/*.ts        → business logic + SQL queries live here
 - Authorization: routes call
   `jwtSession.validateUserHasRequiredRoles(["admin", "coordinator", ...])` and the
   middleware regex-tests the JWT `sub` against the permitted role list. Known
-  roles: `admin`, `security_admin`, `data_entry`, `coordinator`, `global_admin`,
-  `global_reporting`.
+  JWT roles (`Role` type in `server/types/account-types.ts`): `admin`,
+  `security_admin`, `data_entry`, `coordinator`, `global_admin`.
+  `global_reporting` is not one of them — it only exists as an `is_global_reporting`
+  boolean column on the account, not a role encoded on the JWT `sub`.
 - Every admin-facing mutating route is expected to carry a role check — that
   pattern should hold without exception. Don't assume a sibling route's
   presence or absence of a role check is precedent; verify it against what the
@@ -129,6 +131,9 @@ unless noted. The root `package.json` only exposes `typecheck` (via
 Before telling the user "tests pass" or "lint is clean," actually run the command
 above and read the output — do not assume the `npm run <script>` name implies a
 working, CI-meaningful check (see §7 for exactly where that assumption breaks).
+Run `npm ci` in the relevant workspace first if you haven't already in this
+session — don't assume a clean typecheck/test baseline without confirming the
+lockfile is actually installed.
 
 ## 4. Environment / running locally
 
@@ -146,9 +151,13 @@ working, CI-meaningful check (see §7 for exactly where that assumption breaks).
   **only** test workflow: runs client Playwright E2E tests against a locally
   started Vite dev server, on push/PR to `main`/`master`/`develop`.
 - There is **no CI step** that runs server Jest tests, client Jest tests, either
-  workspace's lint, or `tsc --noEmit`. A Husky `pre-commit` hook
-  (`lerna run lint`, in root `package.json`) is the only local gate, and it only
-  covers lint — and only for people who have Husky installed locally.
+  workspace's lint, or `tsc --noEmit`. Root `package.json` declares a Husky
+  `pre-commit` hook (`lerna run lint`) via the legacy `"husky": { "hooks": {...} }`
+  config key, but the installed `husky` version is `^9`, which ignores that key
+  entirely and only runs hooks from a `.husky/` directory — there is no
+  `.husky/` directory and no `prepare` script to create one. So this hook is
+  **not active for anyone** right now, not just for contributors without Husky
+  installed; don't rely on it as a gate.
 - Deploys: pushes to `main`/`develop`/`vite` branches auto-deploy to matching
   Heroku apps (`foodoasis`, `foodoasisdev`, `foodoasisvite`) via
   `akhileshns/heroku-deploy`. Two Docker Hub publish workflows exist but are
@@ -194,11 +203,12 @@ commands — not guesses:
 - **Client lint is broken.** `client/package.json`'s `lint` script runs
   `eslint -c .eslintrc.json ...`, and `.eslintrc.json` extends `"react-app"` (the
   Create React App / `eslint-config-react-app` preset). But the client no longer
-  uses CRA — it's Vite — and `eslint-config-react-app` isn't installed as a
-  dependency anywhere in the client. Running the lint script fails outright
-  ("ESLint couldn't find the config 'react-app'"). This is leftover from the
-  CRA→Vite migration. Until this is fixed, don't treat "client lint passed" as a
-  meaningful signal — it can't currently run at all. Recommended: replace with a
+  uses CRA — it's Vite — and `eslint` itself isn't installed as a dependency
+  anywhere in the client (or the root). Running the lint script fails outright
+  with `sh: eslint: command not found` — it never gets far enough to fail on
+  the missing `react-app` config. This is leftover from the CRA→Vite migration.
+  Until this is fixed, don't treat "client lint passed" as a meaningful signal
+  — it can't currently run at all. Recommended: replace with a
   flat ESLint config for TS/React (mirroring server's approach) as a follow-up.
 - **Client Jest unit tests are broken.** `client/src/__test__/App.test.js` and
   `Helpers.test.js` fail to even parse: `client/src/helpers/index.ts` uses a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,304 @@
+# CLAUDE.md — Food Oasis Development Rules
+
+This file is the project-wide reference for AI agents (and humans) working in this
+repository. It reflects what actually exists in the codebase as of this writing, not
+aspirational conventions. Where the codebase is inconsistent, that is called out
+explicitly rather than papered over.
+
+Two companion files define the two-agent workflow that should be used for
+non-trivial changes:
+
+- [.claude/agents/implementer.md](.claude/agents/implementer.md)
+- [.claude/agents/reviewer.md](.claude/agents/reviewer.md)
+- [docs/agent-workflow.md](docs/agent-workflow.md) — how the two agents hand off to each other
+- [docs/review-checklist.md](docs/review-checklist.md) — the reviewer's checklist
+
+## 1. What this project is
+
+Food Oasis is a directory of food pantries and meal programs, serving multiple
+regions (**multi-tenant**, one deployment, tenant-scoped data) via one codebase:
+LA County, Hawaiian Islands, Santa Barbara County, and McKinney TX
+(`la.foodoasis.net`, `hi.foodoasis.net`, `sb.foodoasis.net`, `mck.foodoasis.net`).
+It is a Hack for LA open-source civic tech project (GPL-2.0).
+
+It is a **monorepo** with two npm workspaces coordinated by **Lerna**:
+
+- `client/` — React SPA (public food-seeker search + admin/data-entry back office)
+- `server/` — Express REST API (`/api/*`)
+
+There is no shared package between them; they communicate purely over HTTP/JSON.
+
+## 2. Architecture
+
+### Server (`server/`)
+
+Layered, one Express `Router` per resource:
+
+```
+routes/*.ts        → validates auth/role, wires middleware, calls controller
+controllers/*.ts    → thin: parses req, calls service, shapes res
+services/*.ts        → business logic + SQL queries live here
+```
+
+- Entry point: [server/server.ts](server/server.ts). All routers are mounted in
+  [server/app/routes/index.ts](server/app/routes/index.ts) under `/api/<resource>`.
+- Database access is **pg-promise**, via the singleton exported from
+  [server/app/services/db.ts](server/app/services/db.ts). Every service imports
+  `db` from there and writes raw SQL using named parameters: `db.one(sql, { id })`,
+  `` `where id = $<id>` ``. This is the standard, correct pattern — reuse it.
+  - `server/app/services/postgres-pool.ts` (a plain `pg.Pool`) and the `massive`
+    npm dependency are **dead code** — not imported anywhere. Do not build new
+    features on them; don't be surprised they exist.
+- Request body validation is done selectively with **ajv** JSON Schemas
+  (`app/validation-schema/*.ts`) run through
+  [server/middleware/request-validation-middlewares.ts](server/middleware/request-validation-middlewares.ts).
+  It is only wired up on some POST/PUT routes (see §7, "Areas of technical debt").
+- DB schema changes go through **node-pg-migrate** migrations in
+  `server/migrations/` (54+ timestamped files). Never hand-edit the schema outside
+  a migration.
+- camelCase ⇄ snake_case: Postgres columns are `snake_case`; service layer converts
+  rows to camelCase with `camelcase-keys` before returning them. Keep this
+  boundary — camelCase in TS/JSON, snake_case in SQL.
+
+### Client (`client/`)
+
+- React 18 + TypeScript, built with **Vite** (migrated off Create React App —
+  see §7 for the leftover CRA artifacts this left behind).
+- Routing: `react-router-dom` v7, all routes declared in
+  [client/src/Routes.tsx](client/src/Routes.tsx). Admin/back-office routes are
+  gated with [PrivateRoute.tsx](client/src/components/PrivateRoute.tsx), which
+  checks role flags on the user object from `userContext`.
+- State management: no Redux/Zustand/React Query. Global/cross-cutting state
+  (current user, site/tenant config, toaster notifications) lives in three React
+  Context providers under `client/src/contexts/`. Resource-specific data fetching
+  is done with one custom hook per resource in `client/src/hooks/` (e.g.
+  `useOrganizations`, `useCategories`), each wrapping a matching module in
+  `client/src/services/` that calls the API with `axios`. Follow this
+  hook-wraps-service pattern for new resources rather than fetching ad hoc from
+  components.
+- UI kit: MUI v5 (`@mui/material`, `@mui/x-data-grid`, `@mui/x-date-pickers`).
+  Theme lives in `client/src/theme/`. Forms use `formik` + `yup` (~17 files use
+  Formik; this is the established form pattern for anything more than a trivial
+  input).
+- Multi-tenant/region behavior on the client is driven by `siteContext`
+  (tenant id, name, map bounds, branding) — check there before hardcoding
+  region-specific text, styling, or category lists.
+- `client/src` is fully TypeScript (`.ts`/`.tsx`); no `.js`/`.jsx` remain except
+  two legacy Jest test files (see §7). Do not introduce new `.js`/`.jsx` files.
+
+### Auth model
+
+- Login: `passport-local` validates email/password against `login`/`login_tenant`
+  tables (bcrypt hash) — [server/middleware/authenticate.ts](server/middleware/authenticate.ts).
+- Session: **stateless JWT**, not server sessions. On login, the server signs a JWT
+  (`server/middleware/jwt-session.ts`) whose `sub` claim encodes the user's roles
+  as a string (e.g. `"admin"` or a role list) and returns it as both a `jwt` cookie
+  and a JSON field, so non-cookie clients work too.
+- Authorization: routes call
+  `jwtSession.validateUserHasRequiredRoles(["admin", "coordinator", ...])` and the
+  middleware regex-tests the JWT `sub` against the permitted role list. Known
+  roles: `admin`, `security_admin`, `data_entry`, `coordinator`, `global_admin`,
+  `global_reporting`.
+- Every admin-facing mutating route is expected to carry a role check — that
+  pattern should hold without exception. Don't assume a sibling route's
+  presence or absence of a role check is precedent; verify it against what the
+  route actually needs (see §8).
+- `stakeholderbests` routes (`/api/stakeholderbests/*`) are intentionally public —
+  they power the unauthenticated food-seeker search — so no JWT check is expected
+  there. Be extra careful with anything unvalidated on that path (see §8).
+- On the client, the JWT is decoded client-side (`atob` on the payload) purely to
+  populate role flags for UI gating — the client never trusts this for anything
+  security-sensitive; the server re-validates on every request.
+
+## 3. Commands (ground-truthed, not aspirational)
+
+Run workspace commands from inside `client/` or `server/`, not the repo root,
+unless noted. The root `package.json` only exposes `typecheck` (via
+`lerna run typecheck`, which fans out to both workspaces) and `release-notes`.
+
+| Task | Client | Server |
+|---|---|---|
+| Install | `npm ci` (from `client/`) | `npm ci` (from `server/`) |
+| Dev server | `npm start` (Vite, port 3000, proxies `/api` to `:5001`) | `npm start` (`ts-node-dev`, port 5001, watches & respawns) |
+| Build | `npm run build` (`tsc && vite build`) | `npm run build` (`tsc`, output to `server/build`) |
+| Typecheck | `npm run typecheck` (`tsc --noEmit`) — **passes clean today** | `npm run typecheck` (`tsc --noEmit`) — **passes clean today** |
+| Lint | `npm run lint` — **currently broken**, see §7 | `npm run lint` (flat ESLint config) — **passes clean today** |
+| Unit tests | `npx jest src/__test__` — **currently broken**, see §7 | `npx jest --ci` (do **not** use `npm test`, it's `jest --watch`) — **10/23 currently failing on stale snapshots**, see §7 |
+| E2E tests | `npx playwright test` (needs `npm start` running on `:3000` first; this is what CI actually runs) | — |
+
+Before telling the user "tests pass" or "lint is clean," actually run the command
+above and read the output — do not assume the `npm run <script>` name implies a
+working, CI-meaningful check (see §7 for exactly where that assumption breaks).
+
+## 4. Environment / running locally
+
+- Postgres is required. `docker-compose.yml` spins up Postgres 11 plus the API in
+  Docker; alternatively point `server/.env` (`POSTGRES_*` or `DATABASE_URL`) at a
+  local/dev instance. `server/db/demo-db/foodoasis.sql` is a seedable demo dataset.
+- `server/db/config.js` and `server/app/services/db.ts` both read the same
+  `POSTGRES_*`/`DATABASE_URL` env vars — keep them in sync if you ever touch
+  connection config.
+- Migrations: `npm run migrate` in `server/` (node-pg-migrate).
+
+## 5. CI/CD (what's actually enforced)
+
+- [.github/workflows/playwright.yml](.github/workflows/playwright.yml) is the
+  **only** test workflow: runs client Playwright E2E tests against a locally
+  started Vite dev server, on push/PR to `main`/`master`/`develop`.
+- There is **no CI step** that runs server Jest tests, client Jest tests, either
+  workspace's lint, or `tsc --noEmit`. A Husky `pre-commit` hook
+  (`lerna run lint`, in root `package.json`) is the only local gate, and it only
+  covers lint — and only for people who have Husky installed locally.
+- Deploys: pushes to `main`/`develop`/`vite` branches auto-deploy to matching
+  Heroku apps (`foodoasis`, `foodoasisdev`, `foodoasisvite`) via
+  `akhileshns/heroku-deploy`. Two Docker Hub publish workflows exist but are
+  explicitly commented "not currently used, as the web app is running on Heroku."
+  An `awsBastion.yml` workflow scales an AWS bastion ASG up/down manually.
+- Dependabot is active and merged frequently (see recent commit history) —
+  routine dependency bumps are the norm, not something to second-guess.
+
+Because CI doesn't enforce lint/typecheck/unit-tests, **the implementer agent is
+the actual quality gate** for those checks on every change — see
+[.claude/agents/implementer.md](.claude/agents/implementer.md).
+
+## 6. Coding conventions actually in use
+
+- **TypeScript everywhere**, `strict: true` in both `tsconfig.json`s. Both
+  workspaces currently typecheck clean — keep it that way; don't introduce `any`
+  to silence an error (server ESLint has `@typescript-eslint/no-explicit-any`
+  turned **off**, so the linter won't stop you, but it's still against the grain
+  of a strict-mode codebase).
+- **Formatting**: Prettier in both workspaces (`npm run format`), enforced via
+  ESLint's `prettier/recommended` in `server`. Don't hand-format against it.
+- **SQL**: always parameterized (`db.one(sql, { param })` / `` $<param> `` syntax),
+  *except* in a handful of query-builder helper functions inside
+  `stakeholder-service.ts` and `stakeholder-best-service.ts` that string-interpolate
+  filter values directly into SQL — that is legacy, not a pattern to extend (§8).
+  When touching search/filter SQL, prefer converting the specific clause you touch
+  to a bound parameter over adding another interpolated one.
+- **Naming**: camelCase in TS (client and server), snake_case in SQL/DB — convert
+  at the service boundary with `camelcase-keys`, not ad hoc.
+- **React components**: function components + hooks only; no class components in
+  current code. One resource = one hook (`useX`) + one service module
+  (`x-service.ts`) on the client, one service module (`x-service.ts`) + one
+  controller + one router on the server. New resources should follow this
+  four/five-file shape.
+- **Branching**: `<github-issue-number>-<short-kebab-description>` (e.g.
+  `2695-add-pending-suggestion-to-top-of-org-edit`). PRs target `develop`.
+
+## 7. Known inconsistencies (documented, not silently "fixed")
+
+These are real, current states of the repo, verified by running the actual
+commands — not guesses:
+
+- **Client lint is broken.** `client/package.json`'s `lint` script runs
+  `eslint -c .eslintrc.json ...`, and `.eslintrc.json` extends `"react-app"` (the
+  Create React App / `eslint-config-react-app` preset). But the client no longer
+  uses CRA — it's Vite — and `eslint-config-react-app` isn't installed as a
+  dependency anywhere in the client. Running the lint script fails outright
+  ("ESLint couldn't find the config 'react-app'"). This is leftover from the
+  CRA→Vite migration. Until this is fixed, don't treat "client lint passed" as a
+  meaningful signal — it can't currently run at all. Recommended: replace with a
+  flat ESLint config for TS/React (mirroring server's approach) as a follow-up.
+- **Client Jest unit tests are broken.** `client/src/__test__/App.test.js` and
+  `Helpers.test.js` fail to even parse: `client/src/helpers/index.ts` uses a
+  TS type-only named import (`import dayjs, { type Dayjs } from "dayjs"`) that the
+  configured Babel/ts-jest pipeline chokes on. There is also no `npm test` script
+  for these — `client/package.json`'s `test` script actually launches Playwright
+  (`playwright test --ui --headed`), not Jest. **Playwright is the client's real,
+  working test suite** (7 spec files in `client/tests/`, and it's what CI runs);
+  treat the two Jest files as effectively dead until someone fixes the transform
+  config.
+- **Server Jest has 10/23 failing tests today**, all in
+  `server/__test__/account.test.ts`, all `toMatchInlineSnapshot` failures where the
+  snapshot format is stale (`Object { ... }` vs `{ ... }`, a pretty-format version
+  difference from an old Jest). The other two server test files pass. Don't
+  assume "server tests pass" without running them; a red account.test.ts is
+  currently normal, not necessarily something your change broke — but check the
+  diff, since it could also be your change.
+- **`server/test/test_neighborhood_service.ts`** exists (hits a real DB via
+  `mocha`-style bare `it()` blocks — `mocha` is a server devDependency) but is
+  **not picked up by Jest** (wrong location/naming for Jest's default test glob)
+  and there is no `mocha` script to run it either. It appears to be orphaned —
+  treat it as reference/dead code, not a test that runs anywhere, until proven
+  otherwise.
+- **Two competing DB access modules**: `server/app/services/db.ts` (pg-promise —
+  used by every real service) and `server/app/services/postgres-pool.ts` (plain
+  `pg.Pool` — imported nowhere). Same for the `massive` npm package (a dependency,
+  unused). Use `db.ts`.
+- **Request-body validation is inconsistent**: some POST/PUT routes run an ajv
+  schema via `requestValidationMiddleware` (e.g. `stakeholder-router.ts`), others
+  don't validate the body shape at all before it reaches the service. When adding
+  a new mutating route, prefer adding a schema and wiring the middleware, matching
+  the routes that already do it, rather than skipping it because some siblings do.
+
+## 8. Security discipline — read before touching auth, SQL, or secrets
+
+This is a public open-source repository, so this section deliberately states
+**rules to follow**, not an inventory of specific current weaknesses — don't
+turn it (or a commit message, PR description, issue, or code comment) into a
+writeup of exactly how a particular endpoint or query is currently exploitable.
+If you find something concrete while working, stop and raise it with the user
+directly instead of documenting it in anything that gets committed; let the
+user decide how and where to track it (e.g. a private security advisory).
+
+- **Every mutating route (`POST`/`PUT`/`DELETE`) must carry an explicit
+  role/auth check** appropriate to its sensitivity, matching sibling routes for
+  the same resource. Never remove, comment out, or weaken an existing check as
+  a side effect of an unrelated change. If you notice a route that appears to
+  be missing one, don't treat it as precedent to copy and don't "fix" it
+  silently — flag it to the user so it gets its own deliberate, reviewed fix.
+- **All SQL must be parameterized** (`db.one(sql, { param })` / `` $<param> ``
+  syntax) — never string-interpolate a value into a SQL string. The
+  query-builder helpers in
+  [server/app/services/stakeholder-service.ts](server/app/services/stakeholder-service.ts)
+  and [server/app/services/stakeholder-best-service.ts](server/app/services/stakeholder-best-service.ts)
+  predate this rule and still build filter clauses via string interpolation —
+  that's legacy debt, not a pattern to copy or extend. When you touch any of
+  those helpers, convert the specific parameter you're touching to a bound
+  parameter rather than adding another interpolated one, and treat any diff in
+  this area as high-scrutiny regardless of how small it looks (see
+  [docs/review-checklist.md](docs/review-checklist.md)).
+- **Secrets must come from environment variables in every deployed
+  environment.** Don't rely on a hardcoded fallback value for anything
+  security-relevant (e.g. a signing secret) reaching a non-local environment.
+  If you find a hardcoded fallback for a secret in
+  [server/middleware/jwt-session.ts](server/middleware/jwt-session.ts) or
+  elsewhere, don't repeat the literal value in commits, comments, or docs —
+  and don't "fix" it unprompted; flag it to the user, since hardening it can
+  have deployment implications they need to confirm.
+- **File upload / import**: `import-controller.ts` accepts CSV uploads (via
+  `multer`) that get parsed and bulk-inserted — validate any changes here for
+  size/type limits and injection via CSV content.
+- **Multi-tenant data isolation**: nearly every table and query is scoped by
+  `tenant_id`. Any new query must filter by tenant (or explicitly justify why not,
+  e.g. truly global lookups like categories). A missing `tenant_id` filter is a
+  cross-tenant data leak, not just a bug.
+- Secrets (`server/.env`) are git-ignored; never commit real credentials, and
+  never print `.env` contents into logs, PR descriptions, or commit messages.
+
+## 9. Documentation that already exists
+
+- [README.md](README.md) — project overview, regions, contribution entry point.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — points to the GitHub wiki for onboarding
+  and the actual "Contributing Code" process; wiki is the source of truth for
+  human contributor process, not this repo.
+- `doc/` — deployment/Docker/dev-environment notes (`development-environments.md`,
+  `developing-in-docker.md`, `deploy-docker-container-to-heroku.md`).
+- `embed/README.md` — the embeddable widget subproject.
+- `thunder-tests/` — a Thunder Client (VS Code REST client) collection for
+  manually exercising the API; useful as a live example of real request shapes.
+
+## 10. What NOT to do
+
+- Don't add new features on `postgres-pool.ts` or `massive` — use `db.ts`.
+- Don't add new string-interpolated SQL — use `$<param>` bound parameters, even
+  inside the existing query-builder helpers if you're touching them anyway.
+- Don't assume `npm run lint` (client) or `npm test` (either workspace) do what
+  their names imply — see §7 and always verify by running them.
+- Don't silently "fix" an inconsistency documented in §7 as a drive-by inside an
+  unrelated change — flag it and let the human decide whether it's in scope.
+- Don't introduce new global state managers (Redux, Zustand, etc.) or new data
+  fetching libraries (React Query, SWR) — the Context + custom-hook pattern is
+  the established convention; raise it with the user first if you think it's
+  insufficient for a specific feature.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,122 @@
+# Two-Agent Development Workflow — Food Oasis
+
+This describes how the **implementer** and **reviewer** agents work together on
+a change in this repo. Their individual instructions live in
+[.claude/agents/implementer.md](../.claude/agents/implementer.md) and
+[.claude/agents/reviewer.md](../.claude/agents/reviewer.md). Project-wide rules
+both agents follow are in [CLAUDE.md](../CLAUDE.md). The reviewer's checklist is
+[review-checklist.md](review-checklist.md).
+
+## Why two agents
+
+CI in this repo only runs Playwright E2E tests (see CLAUDE.md §5) — nothing
+enforces lint, typecheck, or unit tests, and the client's own lint/unit-test
+tooling is currently broken (CLAUDE.md §7). There is no automated quality gate
+to lean on. Splitting implementation from review, with the reviewer explicitly
+barred from fixing things itself on the first pass, is what stands in for that
+missing gate: one perspective builds and self-checks, a second, independent
+perspective verifies before anything is considered finished.
+
+## The sequence
+
+```
+1. Request
+        ↓
+2. Implementer investigates
+   (reads CLAUDE.md, greps for existing patterns, reads migrations,
+    checks CLAUDE.md §8 risk areas)
+        ↓
+3. Implementer writes an implementation plan
+   (files to touch, pattern being followed, auth/validation/test plan,
+    assumptions, risk flags)
+        ↓
+4. User approval
+   — required when the plan touches auth/roles, the SQL query-builder
+     risk area, needs a new migration, introduces a new library/pattern,
+     was ambiguous, or is large/hard to reverse.
+   — optional for small, unambiguous, low-risk changes clearly within
+     existing patterns (implementer may proceed, but still records the plan).
+        ↓
+5. Implementer implements incrementally
+   (matches existing file conventions, reuses existing abstractions,
+    never adds new string-interpolated SQL)
+        ↓
+6. Implementer runs checks
+   (typecheck + lint + tests + build for touched workspace(s); compares
+    test failures against the known baselines in CLAUDE.md §7 rather than
+    assuming red = their fault or green = all clear)
+        ↓
+7. Implementer reviews its own diff
+   (git diff, read top to bottom, check for drift from the plan, leftover
+    debug code, missed reuse opportunities)
+        ↓
+8. Implementer documents what changed
+   (file-by-file summary, assumptions, check results, remaining concerns,
+    follow-ups worth a separate task)
+        ↓
+9. Reviewer independently reviews
+   (does NOT modify application code; re-derives correctness rather than
+    trusting the implementer's summary; runs its own typecheck/lint/tests;
+    works through review-checklist.md in full)
+        ↓
+10. Reviewer returns a verdict
+    APPROVED  → go to step 12
+    CHANGES REQUESTED → findings listed by severity (Blocker/Major/Minor/Nit)
+    with concrete, pattern-referencing recommendations → go to step 11
+        ↓
+11. Implementer addresses findings
+    (fixes in severity order, or states explicitly why a finding doesn't
+     apply — never silently ignores one; re-runs relevant checks;
+     stays within the scope of the findings, flagging anything larger
+     as a separate follow-up)
+        ↓ back to step 9 (reviewer re-reviews only the new diff)
+        ↓
+12. Reviewer performs final review → APPROVED
+        ↓
+13. Complete
+```
+
+## Handoff contract
+
+What the implementer must hand the reviewer:
+- The diff (or a pointer to it — branch/commit range).
+- The original request/requirement, if not already obvious from context.
+- The Step 8 summary: what changed and why, assumptions, check results
+  (explicitly pass/fail per workspace/check, with any pre-existing failures
+  called out), remaining concerns, follow-ups.
+
+What the reviewer must hand back:
+- Either APPROVED (with a brief confirmation of what was verified), or
+- CHANGES REQUESTED with every Blocker/Major finding stated as: file + line,
+  what's wrong, concrete failure scenario, severity, and a recommendation that
+  references an existing repo pattern where one applies.
+
+## Escalating to the user
+
+Either agent should pause and ask the user rather than guess when:
+- A requirement is genuinely ambiguous and the two readings lead to materially
+  different implementations.
+- A change would touch one of the CLAUDE.md §8 security discipline areas in a
+  way beyond a narrow, in-place fix (e.g. "should we fix an auth check we
+  noticed is missing on an unrelated route as part of this?" is a question for
+  the user, not a decision either agent should make unilaterally).
+- Fixing a review finding properly would require a scope the user hasn't
+  approved (e.g. fixing client lint tooling repo-wide to satisfy one PR).
+- The reviewer and implementer are at an impasse after a round of findings
+  (implementer believes a finding doesn't apply, reviewer disagrees) — don't
+  loop indefinitely, surface the disagreement.
+- **Either agent identifies a concrete, currently-exploitable security issue.**
+  This repo is public — never write the specifics (which endpoint, which
+  parameter, why it's exploitable) into a commit, PR description, issue, or any
+  committed file, including this one. Surface it to the user directly and let
+  them decide where it gets tracked (e.g. a private GitHub Security Advisory).
+
+## What this workflow deliberately does not cover
+
+- Trivial changes (typo fixes, a one-line copy change) don't need the full
+  ceremony — use judgment. The workflow exists for non-trivial changes where
+  independent verification actually earns its cost.
+- This workflow doesn't replace human code review on the eventual PR — it's a
+  pre-PR quality pass. Standard Hack for LA / GitHub PR process (see
+  [CONTRIBUTING.md](../CONTRIBUTING.md) and the project wiki) still applies on
+  top of it.

--- a/docs/review-checklist.md
+++ b/docs/review-checklist.md
@@ -45,7 +45,7 @@ applies to every change (e.g. a client-only CSS tweak skips the SQL section).
 - [ ] Existing abstractions reused where they fit (existing hook extended
       rather than duplicated; existing validation schema extended rather than
       a parallel one created).
-- [ ] TypeScript types reused from `server/app/types/` / `client/src/types/`
+- [ ] TypeScript types reused from `server/types/` / `client/src/types/`
       rather than redeclared inline.
 
 ## 4. Database & migrations

--- a/docs/review-checklist.md
+++ b/docs/review-checklist.md
@@ -1,0 +1,163 @@
+# Review Checklist — Food Oasis
+
+Used by the reviewer agent ([.claude/agents/reviewer.md](../.claude/agents/reviewer.md))
+for every review pass. Grounded in this repo's actual architecture, described in
+[CLAUDE.md](../CLAUDE.md) — check off what applies to the diff; not every item
+applies to every change (e.g. a client-only CSS tweak skips the SQL section).
+
+## 1. Requirement satisfaction
+
+- [ ] The change actually does what was requested — re-derive this from the
+      diff and the stated requirement, don't take the implementer's word for it.
+- [ ] No silent scope reduction (a hard part of the request quietly dropped)
+      or scope creep (unrelated changes bundled in) without it being called out.
+- [ ] Edge cases implied by the request are handled (empty results, no
+      matching tenant, missing optional fields), not just the happy path.
+
+## 2. Correctness
+
+- [ ] Logic does what the code appears to intend — trace at least one
+      non-trivial branch by hand.
+- [ ] Async code handles rejections (server: try/catch or `.catch` at the
+      controller boundary, matching the pattern in sibling controllers; client:
+      hooks set an error state on the `catch` path, matching `useOrganizations`'s
+      shape).
+- [ ] Off-by-ones, null/undefined handling (`user === undefined` vs `null` is
+      meaningful in `userContext` — "not yet loaded" vs "not logged in"; don't
+      collapse that distinction accidentally).
+- [ ] `camelcase-keys` is applied at the service return boundary for any new
+      query that returns DB rows to a controller — not applied ad hoc later, not
+      skipped.
+
+## 3. Architecture & convention fit (CLAUDE.md §2, §6)
+
+- [ ] Server: new logic lives in the right layer (route = auth/wiring only,
+      controller = thin request/response shaping, service = business logic +
+      SQL). A route or controller with real business logic in it is a finding.
+- [ ] Client: new data fetching follows hook-wraps-service, not fetching
+      directly inside a component.
+- [ ] New resource, if any, has the conventional file set (router + controller
+      + service [+ validation schema] on the server; hook + service on the
+      client) rather than being bolted onto an unrelated existing file.
+- [ ] No new state-management library, data-fetching library, or SQL access
+      pattern introduced without explicit justification — Context+hooks and
+      pg-promise are the established choices (CLAUDE.md §2).
+- [ ] Existing abstractions reused where they fit (existing hook extended
+      rather than duplicated; existing validation schema extended rather than
+      a parallel one created).
+- [ ] TypeScript types reused from `server/app/types/` / `client/src/types/`
+      rather than redeclared inline.
+
+## 4. Database & migrations
+
+- [ ] Any schema change is a `node-pg-migrate` migration in `server/migrations/`,
+      not a hand-written one-off — and has a sensible, reversible `down`.
+- [ ] Every new/changed query is scoped by `tenant_id` where the table has one,
+      or there's an explicit, correct reason it shouldn't be (e.g. genuinely
+      global reference data).
+- [ ] SQL naming stays snake_case; JS/TS stays camelCase; conversion happens
+      once, at the boundary.
+
+## 5. Security (CLAUDE.md §8 — apply carefully, even to small diffs)
+
+This repo is public. Findings in this section go in the review's severity list
+like any other — file, line, failure scenario — but never spell out a
+currently-exploitable specific in a way that would be more useful to an
+attacker than to the person fixing it (e.g. don't write "this lets an
+unauthenticated caller do X against production"; write "this route is missing
+the role check its siblings have" and let the recommendation carry the fix).
+If a finding looks like a live, concrete vulnerability rather than a
+convention violation, raise it with the user directly instead of writing the
+exploit reasoning into the review output.
+
+- [ ] **All new/changed SQL uses parameterized queries** (`db.one(sql, { x })`
+      / `` $<x> ``). Any new string interpolation into a SQL string is a
+      **Blocker**, full stop — including inside `stakeholder-service.ts` /
+      `stakeholder-best-service.ts`'s existing query-builder helpers, which
+      already have this problem and should not gain more of it.
+- [ ] Any new or changed route has the auth/role check appropriate to its
+      sensitivity, matching what sibling routes for the same resource use.
+      A mutating route (`POST`/`PUT`/`DELETE`) with no role check is a
+      **Blocker** unless it's deliberately public and that's justified (rare —
+      `stakeholderbests` search-style routes are the only current example).
+- [ ] If the diff touches a route whose auth/role check looks weaker than its
+      siblings (missing, commented out, or overly permissive), that's a
+      **Blocker** — flag it in the review by pattern ("missing the role check
+      its siblings have"), don't fix it unprompted unless that's the actual
+      task, and don't narrate why/how it's exploitable in the written review.
+- [ ] No secrets, credentials, or `.env` contents introduced into source,
+      comments, logs, or commit messages.
+- [ ] File upload handling (if touched) still constrains size/type; CSV import
+      logic doesn't trust file content beyond what it did before.
+- [ ] No hardcoded fallback value for a secret (e.g. `JWT_SECRET`) is reachable
+      in a way that could apply outside local dev — deployed environments must
+      set the real env var. Don't repeat the literal fallback value in the
+      review.
+
+## 6. Error handling & resilience
+
+- [ ] Server: errors return an appropriate status code (401 for auth failures
+      matching `jwt-session.ts`'s pattern, 400 for bad input, 500 only for
+      truly unexpected failures) — not everything collapsed to 500 or 200.
+- [ ] Client: network/API failures surface to the user via the existing
+      toaster pattern (`toasterContext`) rather than failing silently or only
+      logging to console.
+- [ ] No swallowed exceptions (empty `catch` blocks) without a comment
+      explaining why swallowing is correct there.
+
+## 7. Performance
+
+- [ ] No obvious N+1 query pattern introduced (a loop issuing one query per
+      iteration where a single joined/batched query would do).
+- [ ] Large result sets (stakeholder search, exports) aren't fully loaded into
+      memory unnecessarily where the existing code already streams/paginates.
+- [ ] No new unbounded query (missing a `LIMIT`/pagination) on a table that can
+      grow large, unless matching existing unbounded queries deliberately.
+
+## 8. Accessibility (client changes)
+
+- [ ] Interactive elements are real interactive elements (`button`, `a`,
+      form controls) or have the appropriate ARIA role — not a `div` with an
+      `onClick` and nothing else.
+- [ ] New form fields have associated labels (Formik + MUI's `TextField`
+      `label` prop is the existing pattern — use it).
+- [ ] Images/icons convey meaning via `alt` text or `aria-label`, matching
+      how existing icon components in `client/src/icons/` are used.
+- [ ] Color is not the only signal for state (error/success), consistent with
+      existing MUI theme usage (icons/text alongside color).
+- [ ] Keyboard navigation isn't broken by a new custom interactive component
+      (prefer MUI components, which handle this, over hand-rolled ones).
+
+## 9. Test coverage
+
+- [ ] Non-trivial new server logic has a Jest unit test in `server/__test__/`
+      following the existing `jest.mock(...)` + controller-level test pattern
+      seen in `account.test.ts` / `stakeholder-controller.test.ts`.
+- [ ] A new user-facing flow on the client has (or should have) Playwright
+      coverage added to `client/tests/`, matching the existing spec file
+      pattern — this is the client's only currently-working test suite
+      (CLAUDE.md §7), so it's the meaningful place to add coverage, not the
+      broken Jest setup.
+- [ ] Existing tests weren't weakened to make them pass (loosened assertions,
+      skipped tests, deleted coverage) without explicit justification.
+- [ ] Test-run results reported by the implementer were actually verified,
+      not just repeated — check failures against the known baselines
+      (CLAUDE.md §7: 10 pre-existing `account.test.ts` snapshot failures;
+      client Jest fully broken; client lint fully broken) rather than assuming
+      any red/green is meaningful without checking it against those.
+
+## 10. Diff hygiene
+
+- [ ] No leftover debug code (`console.log`, commented-out blocks, dead code
+      paths).
+- [ ] No unrelated formatting-only churn mixed into a functional diff.
+- [ ] No unnecessary new dependency added when the existing dependency set
+      already covers the need (check `package.json` diffs specifically).
+- [ ] Naming in new code matches the file/module's existing naming style.
+
+## Verdict
+
+After working through the applicable sections: any unresolved Blocker or
+Major → **CHANGES REQUESTED**, findings listed with file/line, concrete
+failure scenario, and severity. Otherwise → **APPROVED**, with a brief note of
+what was verified (checks run, sections applied).


### PR DESCRIPTION
## Closes #2854 

## Summary

Adds a documentation-only, two-agent (implementer + reviewer) AI development
workflow for this repo: a root `CLAUDE.md` capturing the project's actual
architecture/conventions/tech debt, subagent definitions for the implementer
and reviewer roles, a workflow doc describing how they hand off, and a review
checklist scoped to this codebase's real patterns.

**No application code changed.**

## What's included

- `CLAUDE.md` — ground-truthed project reference: architecture, commands,
  testing/CI reality, coding conventions, known inconsistencies, security
  discipline rules
- `.claude/agents/implementer.md` — investigates → plans → implements → runs
  checks → self-reviews → documents
- `.claude/agents/reviewer.md` — independently reviews (no app-code edits on
  the first pass), checklist-driven, returns a severity-classified verdict
- `docs/agent-workflow.md` — the full request → plan → approval → implement →
  review → done sequence, plus rules for when to escalate to the user
- `docs/review-checklist.md` — review checklist tailored to this repo's real
  patterns (correctness, architecture fit, DB/migrations, security, error
  handling, performance, accessibility, test coverage, diff hygiene)

## Why

CI here only runs Playwright E2E — there's no lint/typecheck/unit-test gate
(see `CLAUDE.md` §5), and the client's own lint/Jest tooling is currently
broken. This workflow gives non-trivial changes a documented
investigate-plan-implement-review loop with an independent verification pass,
standing in for the missing automated gate.

## Notes

- Repo inspection findings are documented as known inconsistencies/technical
  debt (broken client lint, broken client Jest, stale server snapshot tests,
  dead DB-access code) rather than silently fixed — see `CLAUDE.md` §7.
- The security section (`CLAUDE.md` §8) deliberately states rules/conventions
  to follow rather than detailing specific current weaknesses, since this is
  a public repo.
- No behavior, dependency, or schema changes.

## Verification

Docs-only change. Claims about current pass/fail state (typecheck, lint,
Jest, per workspace) were verified by actually running those commands against
this branch, not assumed from script names.

