### PR TITLE
Add aria-label to filter panel close button

### DIFF
--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/FilterPanel.tsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/FilterPanel.tsx
@@ -152,7 +152,7 @@ const FilterPanel: FC<FilterPanelProps> = ({ mealPantry, filterCount }) => {
             {`${filterCount} ${filterCount === 1 ? "Location" : "Locations"}`}
           </Typography>
           {isDesktop ? (
-            <IconButton onClick={handleDrawerClose}>
+            <IconButton aria-label="Close filters" onClick={handleDrawerClose}>
               <CloseIcon />
             </IconButton>
           ) : (

--- a/client/tests/organizations.spec.ts
+++ b/client/tests/organizations.spec.ts
@@ -157,4 +157,18 @@ test.describe("Organizations", () => {
     await expect(page.getByText("Stakeholder 2")).toBeVisible();
     await expect(page.getByText("Stakeholder 3")).toBeHidden();
   });
+
+  test("filter panel close button has an accessible name and closes the panel", async ({
+    page,
+  }) => {
+    await mockRequests(page);
+    await page.goto("/organizations");
+    await page.getByRole("button", { name: "More Filters" }).click();
+
+    const closeFilters = page.getByRole("button", { name: "Close filters" });
+    await expect(closeFilters).toBeVisible();
+
+    await closeFilters.click();
+    await expect(closeFilters).toBeHidden();
+  });
 });


### PR DESCRIPTION
## What changed
Add `aria-label="Close filters"` to the desktop close button (icon-only `IconButton`) in the search results filter panel.

Add a Playwright test that verifies the button is reachable by its accessible name and closes the panel.

## Why
The button at `FilterPanel.tsx:155` rendered only a `<CloseIcon />` with no text and no `aria-label`, so its accessible name was empty. A screen reader announced it just as "button", giving no hint of its purpose.

The fix follows the file's own convention: the sibling clear-filter button already uses `aria-label="Clear organization name filter"`, and `AnnouncementSnackbar` uses `aria-label="close"`.

Verified empirically: with the source fix reverted, the new test fails (`getByRole("button", { name: "Close filters" })` finds nothing); with the fix, it passes.

## How to verify
```bash
cd client
npm ci
npx playwright install chromium
npm run start &                       # vite dev server on :3000
npx wait-on http://localhost:3000
CI=1 npx playwright test tests/organizations.spec.ts --project=chromium
```