### PR TITLE
fix(security): stop GET /accounts/:email leaking password hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ node_modules/
 /client/playwright-report/
 /client/blob-report/
 /client/playwright/.cache/
+/.cursor

--- a/server/__test__/account.test.ts
+++ b/server/__test__/account.test.ts
@@ -252,34 +252,40 @@ describe("Account", () => {
       params: { email: "admin@test.com" },
     });
     const next = mockNext();
-    const selectByEmailMock =
-      accountService.selectByEmail as jest.MockedFunction<
-        typeof accountService.selectByEmail
+    const account = accounts[2];
+    // The controller must use the public-safe lookup, which never exposes the
+    // bcrypt password hash or privilege flags (security audit finding #1).
+    const selectByEmailPublicMock =
+      accountService.selectByEmailPublic as jest.MockedFunction<
+        typeof accountService.selectByEmailPublic
       >;
-    selectByEmailMock.mockImplementationOnce(() =>
-      Promise.resolve(accounts[2])
+    selectByEmailPublicMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        id: account.id,
+        firstName: account.firstName,
+        lastName: account.lastName,
+        email: account.email,
+        emailConfirmed: account.emailConfirmed,
+        dateCreated: account.dateCreated,
+      })
     );
     await accountController.getByEmail(req, res, next);
-    expect(selectByEmailMock).toHaveBeenCalledWith("admin@test.com", 1);
-    expect(selectByEmailMock).toHaveBeenCalledTimes(1);
-    expect(res.send.mock.calls[0][0]).toMatchInlineSnapshot(`
+    expect(selectByEmailPublicMock).toHaveBeenCalledWith("admin@test.com", 1);
+    expect(selectByEmailPublicMock).toHaveBeenCalledTimes(1);
+    const sent = res.send.mock.calls[0][0];
+    // Guard against regressions that reintroduce the leak.
+    expect(sent.data).not.toHaveProperty("passwordHash");
+    expect(sent.data).not.toHaveProperty("isAdmin");
+    expect(sent.data).not.toHaveProperty("isGlobalAdmin");
+    expect(sent).toMatchInlineSnapshot(`
      {
        "data": {
          "dateCreated": "2021-05-18T06:04:09.421Z",
          "email": "admin@test.com",
          "emailConfirmed": false,
-         "features": [],
          "firstName": "Admin",
          "id": 171,
-         "isAdmin": false,
-         "isCoordinator": false,
-         "isDataEntry": true,
-         "isGlobalAdmin": false,
-         "isGlobalReporting": false,
-         "isSecurityAdmin": false,
          "lastName": "Admin",
-         "passwordHash": "$2b$10$aMAO10PCC2RfcmXg1GCH1.UsccMgTB53h4XD2w9ydlQMrf4Nn55.q",
-         "tenantId": 1,
        },
        "isSuccess": true,
      }

--- a/server/app/controllers/account-controller.ts
+++ b/server/app/controllers/account-controller.ts
@@ -51,7 +51,9 @@ const getByEmail: RequestHandler<
   try {
     const { email } = req.params;
     const { tenantId } = req.query;
-    const response = await accountService.selectByEmail(email, tenantId);
+    // Use the public-safe lookup so the bcrypt password hash and privilege
+    // flags are never returned to the client (see security audit finding #1).
+    const response = await accountService.selectByEmailPublic(email, tenantId);
     res.send({ isSuccess: true, data: response });
   } catch (err: any) {
     console.error(err);

--- a/server/app/services/account-service.ts
+++ b/server/app/services/account-service.ts
@@ -6,6 +6,7 @@ import { v4 as uuid4 } from "uuid";
 import {
   Account,
   AccountResponse,
+  PublicAccount,
   RegisterFields,
   Role,
   User,
@@ -77,6 +78,25 @@ const selectByEmail = async (
     ...row,
     features: row.features.split(", ").filter(Boolean) || [],
   });
+};
+
+// Public-safe lookup used by the unauthenticated GET /:email endpoint. Strips
+// the bcrypt password hash and all privilege/role flags at the service layer so
+// they can never leak to a client, regardless of the caller. Internal callers
+// that need the hash (e.g. authenticate) must use selectByEmail directly.
+const selectByEmailPublic = async (
+  email: string,
+  tenantId: string
+): Promise<PublicAccount> => {
+  const account = await selectByEmail(email, tenantId);
+  return {
+    id: account.id,
+    firstName: account.firstName,
+    lastName: account.lastName,
+    email: account.email,
+    emailConfirmed: account.emailConfirmed,
+    dateCreated: account.dateCreated,
+  };
 };
 
 const register = async (body: RegisterFields): Promise<AccountResponse> => {
@@ -567,6 +587,7 @@ export default {
   resetPassword,
   selectAll,
   selectByEmail,
+  selectByEmailPublic,
   selectById,
   setGlobalPermissions,
   setTenantPermissions,

--- a/server/types/account-types.ts
+++ b/server/types/account-types.ts
@@ -19,6 +19,17 @@ export interface Account extends User {
   features: string[];
 }
 
+// A public-safe view of an account: excludes the bcrypt password hash and all
+// privilege/role flags so they can never be returned to a client.
+export interface PublicAccount {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  emailConfirmed: boolean;
+  dateCreated?: string;
+}
+
 export interface RegisterFields extends User {
   password: string;
   clientUrl: string;


### PR DESCRIPTION
## Summary

Fixes **security audit finding #1 (Critical)** — the unauthenticated `GET /api/accounts/:email` endpoint returned the full account row, **including the bcrypt `password_hash` and all privilege/role flags**, to any caller. This enabled offline password cracking and account enumeration.

## Approach

`selectByEmail` is shared with internal callers (`authenticate`, profile update) that legitimately need the hash for `bcrypt.compare`, so it can't be stripped at the SQL layer. Instead the strip is done **at the service boundary** (per the audit's "not just by omission at the controller"):

- New `PublicAccount` type — only non-sensitive identity fields.
- New `accountService.selectByEmailPublic()` — returns `id, firstName, lastName, email, emailConfirmed, dateCreated` only.
- `accountController.getByEmail` now calls it, so the hash and privilege flags **can never reach a client** regardless of the caller.

## Compatibility

Both existing callers keep working:
- **Admin `Features.tsx`** — only uses `data.id`
- **Public `ForgotPassword.tsx`** — only uses the 200-vs-404 existence signal

## Tests

- Updated the `getByEmail` unit test to assert the sanitized shape and added `.not.toHaveProperty` guards for `passwordHash` / `isAdmin` / `isGlobalAdmin` to catch regressions.
- `tsc --noEmit` passes clean.
- Note: the `account.test.ts` suite has a **pre-existing** `Object {` vs `{` Jest-serializer snapshot mismatch (10 snapshots, identical on `develop`) unrelated to this change.

## Scope

Intentionally scoped to the **hash leak (#1)** only. Adding auth to this route would break the public forgot-password existence check; the unauthenticated-access / enumeration concern is a separate audit finding (**#10**) with its own recommended fix.

---
🤖 This PR was written by Claude on behalf of @hanapotski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)