### PR TITLE
2117 rename orgNameFilter -> searchFilter to match "Search" UI label

### DIFF
--- a/client/src/appReducer.tsx
+++ b/client/src/appReducer.tsx
@@ -145,10 +145,10 @@ function filterPanelReducer(state: boolean, action: AppAction): boolean {
       return state;
   }
 }
-function orgNameFilterReducer(state: string, action: AppAction): string {
+function searchFilterReducer(state: string, action: AppAction): string {
   switch (action.type) {
-    case "ORG_NAME_FILTER_UPDATED":
-      return action.orgNameFilter;
+    case "SEARCH_FILTER_UPDATED":
+      return action.searchFilter;
     default:
       return state;
   }
@@ -228,7 +228,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     isWidget: widgetReducer(state.isWidget, action),
     stakeholders: stakeholdersReducer(state.stakeholders, action),
     filterPanel: filterPanelReducer(state.filterPanel, action),
-    orgNameFilter: orgNameFilterReducer(state.orgNameFilter, action),
+    searchFilter: searchFilterReducer(state.searchFilter, action),
     openTimeFilter: openTimeFilterReducer(state.openTimeFilter, action),
     foodTypeFilter: foodTypeFilterReducer(state.foodTypeFilter, action),
     listPanel: listPanelReducer(state.listPanel, action),
@@ -251,7 +251,7 @@ export function getInitialState(): AppState {
     neighborhood: null,
     isWidget: false,
     filterPanel: false,
-    orgNameFilter: "",
+    searchFilter: "",
     openTimeFilter: { radio: "Show All", day: "", time: "" },
     foodTypeFilter: [],
     listPanel: true,
@@ -350,9 +350,9 @@ export function useFilterPanel(): boolean {
   return filterPanel;
 }
 
-export function useOrgNameFilter(): string {
-  const { orgNameFilter } = useAppState();
-  return orgNameFilter;
+export function useSearchFilter(): string {
+  const { searchFilter } = useAppState();
+  return searchFilter;
 }
 
 export function useOpenTimeFilter(): OpenTimeFilter {

--- a/client/src/components/FoodSeeker/SearchResults/ResultsFilters/FilterPanel.tsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsFilters/FilterPanel.tsx
@@ -29,7 +29,7 @@ import PantryIconNoBorder from "icons/PantryIconNoBorder";
 import {
   useAppDispatch,
   useFilterPanel,
-  useOrgNameFilter,
+  useSearchFilter,
   useOpenTimeFilter,
   useFoodTypeFilter,
 } from "../../../../appReducer";
@@ -67,7 +67,7 @@ const FilterPanel: FC<FilterPanelProps> = ({ mealPantry, filterCount }) => {
   const dispatch = useAppDispatch() as Dispatch<{ type: string; [key: string]: unknown }>;
   const open = useFilterPanel();
   const openTime = useOpenTimeFilter();
-  const orgNameFilter = useOrgNameFilter();
+  const searchFilter = useSearchFilter();
   const foodTypeFilter = useFoodTypeFilter() as (keyof typeof foodTypeLabelObject)[];
 
   const handleRadioChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -176,11 +176,11 @@ const FilterPanel: FC<FilterPanelProps> = ({ mealPantry, filterCount }) => {
           </Typography>
           <OutlinedInput
             placeholder="i.e. kosher, senior, First Baptist, 90015"
-            value={orgNameFilter}
+            value={searchFilter}
             onChange={(e) =>
               dispatch({
-                type: "ORG_NAME_FILTER_UPDATED",
-                orgNameFilter: e.target.value,
+                type: "SEARCH_FILTER_UPDATED",
+                searchFilter: e.target.value,
               })
             }
             endAdornment={
@@ -190,8 +190,8 @@ const FilterPanel: FC<FilterPanelProps> = ({ mealPantry, filterCount }) => {
                   edge="end"
                   onClick={() =>
                     dispatch({
-                      type: "ORG_NAME_FILTER_UPDATED",
-                      orgNameFilter: "",
+                      type: "SEARCH_FILTER_UPDATED",
+                      searchFilter: "",
                     })
                   }
                 >

--- a/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.tsx
+++ b/client/src/components/FoodSeeker/SearchResults/ResultsMap/ResultsMap.tsx
@@ -30,7 +30,7 @@ import {
   useSearchCoordinates,
   useSelectedOrganization,
   useUserCoordinates,
-  useOrgNameFilter,
+  useSearchFilter,
   useOpenTimeFilter,
 } from "../../../../appReducer";
 import { useMapbox } from "../../../../hooks/useMapbox";
@@ -77,7 +77,7 @@ const ResultsMap = ({
     latitude: number;
     longitude: number;
   } | null;
-  const orgNameFilter = useOrgNameFilter();
+  const searchFilter = useSearchFilter();
   const openTimeFilter = useOpenTimeFilter();
   const navigate = useNavigate();
   const location = useLocation();
@@ -373,7 +373,7 @@ const ResultsMap = ({
 
   useEffect(() => {
     updateUrlParams({
-      name: orgNameFilter || null,
+      name: searchFilter || null,
       pantry: isPantrySelected ? "1" : "0",
       meal: isMealSelected ? "1" : "0",
       openRadio:
@@ -383,7 +383,7 @@ const ResultsMap = ({
       openTime:
         openTimeFilter.radio === "Customized" ? openTimeFilter.time : null,
     });
-  }, [orgNameFilter, isPantrySelected, isMealSelected, openTimeFilter]);
+  }, [searchFilter, isPantrySelected, isMealSelected, openTimeFilter]);
 
   useEffect(() => {
     const timeout = setTimeout(() => {

--- a/client/src/components/FoodSeeker/SearchResults/SearchResults.tsx
+++ b/client/src/components/FoodSeeker/SearchResults/SearchResults.tsx
@@ -58,7 +58,7 @@ const SearchResults = () => {
   const initialZoom = parseFloat(params.get("zoom") || "") || 11;
   const longitudeOffset = 0.08 * Math.pow(2, 11 - initialZoom);
 
-  const orgNameFilter = params.get("name") || "";
+  const searchFilter = params.get("name") || "";
   const radio = params.get("openRadio");
   const day = params.get("openDay") || "";
   const time = params.get("openTime") || "";
@@ -72,10 +72,10 @@ const SearchResults = () => {
         });
       }
 
-      if (orgNameFilter) {
+      if (searchFilter) {
         dispatch({
-          type: "ORG_NAME_FILTER_UPDATED",
-          orgNameFilter,
+          type: "SEARCH_FILTER_UPDATED",
+          searchFilter,
         });
       }
 

--- a/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.tsx
+++ b/client/src/components/FoodSeeker/SearchResults/StakeholderPreview/StakeholderPreview.tsx
@@ -34,7 +34,7 @@ import StakeholderIcon from "images/stakeholderIcon";
 import * as analytics from "services/analytics";
 import {
   useAppDispatch,
-  useOrgNameFilter,
+  useSearchFilter,
   useSearchCoordinates,
   useUserCoordinates,
 } from "../../../../appReducer";
@@ -126,7 +126,7 @@ const StakeholderPreview = ({
   const userCoordinates = useUserCoordinates();
   const originCoordinates = searchCoordinates || userCoordinates;
   const { tenantTimeZone } = useSiteContext();
-  const orgNameFilter = useOrgNameFilter();
+  const searchFilter = useSearchFilter();
 
   const handleSelectOrganization = (organization: SearchStakeholder) => {
     onSelect();
@@ -204,10 +204,7 @@ const StakeholderPreview = ({
                 onClick={() => handleSelectOrganization(stakeholder)}
                 className="notranslate"
               >
-                <HighlightedText
-                  text={stakeholder.name}
-                  query={orgNameFilter}
-                />
+                <HighlightedText text={stakeholder.name} query={searchFilter} />
               </InternalLink>
             </Typography>
             <Stack

--- a/client/src/hooks/useOrganizationBests.ts
+++ b/client/src/hooks/useOrganizationBests.ts
@@ -7,7 +7,7 @@ import {
   useAppDispatch,
   useFoodTypeFilter,
   useOpenTimeFilter,
-  useOrgNameFilter,
+  useSearchFilter,
   useSearchCoordinates,
 } from "../appReducer";
 import * as analytics from "../services/analytics";
@@ -29,7 +29,7 @@ interface StakeholderFilters {
   categoryIds: number[];
   showActiveOnly?: boolean;
   openTimeFilter?: OpenTimeFilter;
-  orgNameFilter?: string;
+  searchFilter?: string;
   foodTypeFilter?: string[];
 }
 
@@ -37,7 +37,7 @@ interface SelectAllParams {
   categoryIds: number[];
 }
 
-// Public-facing text fields searched by the "orgNameFilter" free-text search
+// Public-facing text fields searched by the "searchFilter" free-text search
 // (label reads "Search" in the UI). Deliberately excludes internal/admin-only
 // fields such as `adminNotes` -- only fields a food seeker can already see on
 // the listing/detail page belong here.
@@ -87,7 +87,7 @@ export default function useOrganizationBests() {
   });
   const searchCoordinates = useSearchCoordinates() as Coordinates | null;
   const openTimeFilter = useOpenTimeFilter() as OpenTimeFilter;
-  const orgNameFilter = useOrgNameFilter() as string;
+  const searchFilter = useSearchFilter() as string;
   const foodTypeFilter = useFoodTypeFilter() as string[];
   const { tenantTimeZone } = useSiteContext();
 
@@ -152,9 +152,9 @@ export default function useOrganizationBests() {
           });
         });
       }
-      if (filters.orgNameFilter) {
+      if (filters.searchFilter) {
         const searchWords = filters
-          .orgNameFilter!.toLowerCase()
+          .searchFilter!.toLowerCase()
           .split(" ")
           .filter(Boolean);
         filteredStakeholders = filteredStakeholders.filter((stakeholder) => {
@@ -219,8 +219,8 @@ export default function useOrganizationBests() {
           filters.openTimeFilter = openTimeFilter;
           filters.showActiveOnly = true;
         }
-        if (orgNameFilter) {
-          filters.orgNameFilter = orgNameFilter;
+        if (searchFilter) {
+          filters.searchFilter = searchFilter;
         }
         if (foodTypeFilter.length) {
           filters.foodTypeFilter = foodTypeFilter;
@@ -253,7 +253,7 @@ export default function useOrganizationBests() {
       latitude,
       longitude,
       processStakeholders,
-      orgNameFilter,
+      searchFilter,
       foodTypeFilter,
     ]
   );

--- a/client/src/types/appState.ts
+++ b/client/src/types/appState.ts
@@ -43,7 +43,7 @@ export interface AppState {
   neighborhood: AppNeighborhood | null;
   isWidget: boolean;
   filterPanel: boolean;
-  orgNameFilter: string;
+  searchFilter: string;
   openTimeFilter: OpenTimeFilter;
   foodTypeFilter: string[];
   listPanel: boolean;
@@ -69,7 +69,7 @@ export type AppAction =
   | { type: "RESET_HOVERED_ORGANIZATION" }
   | { type: "WIDGET"; isWidget: boolean }
   | { type: "FILTER_PANEL_TOGGLE"; filterPanel: boolean }
-  | { type: "ORG_NAME_FILTER_UPDATED"; orgNameFilter: string }
+  | { type: "SEARCH_FILTER_UPDATED"; searchFilter: string }
   | { type: "OPEN_TIME_FILTER_UPDATED"; openTimeFilter: OpenTimeFilter }
   | { type: "FOOD_TYPE_FILTER_UPDATED"; foodTypeFilter: string[] }
   | { type: "TOGGLE_LIST_PANEL"; listPanel?: boolean }


### PR DESCRIPTION
Follow-up to #2856.

hanapotski's review on #2856 approved the PR but flagged that internal
state/action names (`orgNameFilter`, `ORG_NAME_FILTER_UPDATED`) still
referenced "org name" even though the field now searches multiple listing
fields and the UI label was changed to "Search".

## What changed
Mechanical rename across state/reducer/hook/action-type/call-sites:
- `orgNameFilter` -> `searchFilter`
- `ORG_NAME_FILTER_UPDATED` -> `SEARCH_FILTER_UPDATED`
- `useOrgNameFilter` -> `useSearchFilter`

The shareable `?name=` URL query parameter key is unchanged, so existing
shared/bookmarked search URLs keep working.

## Not addressed (both explicitly non-blocking in the original review)
- "Expanded matching scope" observation describes intended behavior from
  #2117, not something to change.
- Performance note on rebuilding the per-stakeholder searchable string on
  each filter pass is consistent with how every other filter in
  `useOrganizationBests.ts` already works, and the reviewer called it
  negligible at current scale / worth monitoring, not urgent.

## Checks
- Rebased onto latest `develop`, dependencies reinstalled from the
  committed lockfile (`npm ci` in `client/` and `server/`, no lockfile
  drift).
- `npm run typecheck` (client): **0 errors**, clean. (An earlier run against
  a stale local `node_modules` had shown 144 errors attributed to MUI
  v5→v7 migration debt — that was an artifact of a stale install, not a
  real issue; a clean `npm ci` install typechecks cleanly.)
- `npx playwright test --project=chromium tests/organizations.spec.ts`:
  11/11 passed, re-verified after the rebase + reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)