### PR TITLE
fix(security): remove unauthenticated open email relay (SES)

### DIFF
--- a/server/app/controllers/email-controller.ts
+++ b/server/app/controllers/email-controller.ts
@@ -1,31 +1,7 @@
 import * as emailService from "../services/ses-service";
 import { RequestHandler } from "express";
-import { Email, ContactFormData } from "../../types/email-type";
+import { ContactFormData } from "../../types/email-type";
 import { SendEmailCommandOutput } from "@aws-sdk/client-ses";
-
-const send: RequestHandler<
-  // route params
-  never,
-  // response
-  SendEmailCommandOutput | { error: string },
-  // request
-  Email,
-  // query params
-  never
-> = (req, res) => {
-  const email: Email = {
-    emailFrom: req.body.emailFrom,
-    emailTo: req.body.emailTo,
-    subject: req.body.subject,
-    textBody: req.body.textBody,
-    htmlBody: req.body.htmlBody || req.body.textBody,
-  };
-
-  emailService
-    .send(email)
-    .then((resp) => res.send(resp))
-    .catch((err: any) => res.status(404).json({ error: err.toString() }));
-};
 
 const sendContactForm: RequestHandler<
   // route params
@@ -43,4 +19,4 @@ const sendContactForm: RequestHandler<
     .catch((err: any) => res.status(404).json({ error: err.toString() }));
 };
 
-export { send, sendContactForm };
+export { sendContactForm };

--- a/server/app/routes/email-router.ts
+++ b/server/app/routes/email-router.ts
@@ -1,9 +1,8 @@
 import { Router } from "express";
-import { send, sendContactForm } from "../controllers/email-controller";
+import { sendContactForm } from "../controllers/email-controller";
 
 const router: Router = Router();
 
-router.post("/", send);
 router.post("/contact", sendContactForm);
 
 export default router;

--- a/server/app/services/ses-service.ts
+++ b/server/app/services/ses-service.ts
@@ -1,6 +1,6 @@
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
 import applyEmailTemplate from "./EmailTemplate";
-import { ContactFormData, Email } from "../../types/email-type";
+import { ContactFormData } from "../../types/email-type";
 
 const emailUser: string = process.env.EMAIL_USER || "";
 const awsRegion: string = process.env.AWS_REGION || "us-west-2";
@@ -13,39 +13,6 @@ const sesClient = new SESClient({
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
   },
 });
-
-const send = async (email: Email) => {
-  const params = {
-    Destination: {
-      ToAddresses: [email.emailTo],
-    },
-    Message: {
-      Body: {
-        Html: {
-          Charset: "UTF-8",
-          Data: email.htmlBody,
-        },
-        Text: {
-          Charset: "UTF-8",
-          Data: email.textBody,
-        },
-      },
-      Subject: {
-        Charset: "UTF-8",
-        Data: email.subject,
-      },
-    },
-    Source: email.emailFrom,
-  };
-
-  try {
-    const command = new SendEmailCommand(params);
-    const response = await sesClient.send(command);
-    return response;
-  } catch (err: any) {
-    throw new Error(`Sending email failed. ${err.message || err}`);
-  }
-};
 
 // account verification
 const sendRegistrationConfirmation = async (
@@ -722,7 +689,6 @@ const sendContactConfirmation = async ({
   }
 };
 export {
-  send,
   sendRegistrationConfirmation,
   sendResetPasswordConfirmation,
   sendContactEmail,

--- a/server/types/email-type.ts
+++ b/server/types/email-type.ts
@@ -1,10 +1,3 @@
-export interface Email {
-  emailTo: string;
-  emailFrom: string;
-  subject: string;
-  textBody: string;
-  htmlBody: string;
-}
 export interface ContactFormData {
   name: string;
   message: string;


### PR DESCRIPTION
## Summary

Fixes **security audit finding #3 (Critical)** — `POST /api/emails/` was an **open email relay**. It read `emailFrom`, `emailTo`, `subject`, `htmlBody`, and `textBody` straight from the request body with **no auth, no `Source` allowlist, and no rate limiting**, then passed `emailFrom` through as the SES `Source`. Anyone could send arbitrary phishing/spam email, to any recipient, "From" any address, on the project's verified SES identity — risking AWS billing abuse and domain deliverability/reputation being blacklisted.

## Why remove rather than lock down

The generic relay has **no legitimate caller** — not the client, the embed, or the server. The only references were in the `thunder-tests/` manual API collection (a dev tool). The public contact form (`POST /api/emails/contact`) already covers the real use case **safely**: a fixed template with a server-controlled `Source` (`EMAIL_USER`) and a server-side staff recipient. Bolting auth onto a capability nothing uses would just retain a dangerous arbitrary-send primitive, so the relay is removed entirely.

## Changes

- Drop the `POST /` route (`email-router.ts`).
- Remove the `send` controller handler (`email-controller.ts`).
- Remove `ses-service.send` — the arbitrary-`Source` sender.
- Remove the now-orphaned `Email` type (`email-type.ts`).

## Unaffected

`POST /api/emails/contact` and all templated system emails (registration confirmation, password reset) are unchanged — they already use a server-controlled `Source`.

## Verification

`tsc --noEmit` and `npm run lint` both pass clean. No email unit tests exist to update.

---
🤖 This PR was written by Claude on behalf of @hanapotski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)