### PR TITLE
fix(security): require auth on GET /accounts/:email (account enumeration)

### DIFF
--- a/client/src/components/Account/ForgotPassword.tsx
+++ b/client/src/components/Account/ForgotPassword.tsx
@@ -10,7 +10,6 @@ import {
 } from "@mui/material";
 import Label from "components/Admin/ui/Label";
 import { Formik, FormikHelpers } from "formik";
-import debounce from "lodash.debounce";
 import { useNavigate, useParams } from "react-router-dom";
 import { palette } from "theme/palette";
 import * as Yup from "yup";
@@ -37,24 +36,12 @@ const ForgotPassword: React.FC<ForgotPasswordProps> = () => {
   const { email } = useParams<{ email?: string }>();
   const navigate = useNavigate();
 
-  const debouncedEmailValidation = debounce(
-    async (
-      value: string,
-      setFieldError: (field: string, message: string) => void
-    ) => {
-      try {
-        await accountService.getByEmail(value);
-        return;
-      } catch (e) {
-        console.error(e);
-        setFieldError(
-          "email",
-          "Account not found. If you want to create a new account with this email, please register."
-        );
-      }
-    },
-    500
-  );
+  // Note: we intentionally do NOT probe whether the account exists as the user
+  // types. Looking an email up by GET /api/accounts/:email requires an
+  // authenticated staff role (security audit finding #10), and doing so would
+  // also leak account existence to anonymous visitors. The "account not found"
+  // feedback is surfaced on submit instead, from the forgotPassword response
+  // (FORGOT_PASSWORD_ACCOUNT_NOT_FOUND) below.
 
   return (
     <PageWrapper>
@@ -134,15 +121,8 @@ const ForgotPassword: React.FC<ForgotPasswordProps> = () => {
             handleBlur,
             handleSubmit,
             isSubmitting,
-            setFieldError,
             isValid,
           }) => {
-            const handleEmailChange = (
-              e: React.ChangeEvent<HTMLInputElement>
-            ) => {
-              handleChange(e);
-              debouncedEmailValidation(e.target.value, setFieldError);
-            };
             return (
               <form
                 noValidate
@@ -172,7 +152,7 @@ const ForgotPassword: React.FC<ForgotPasswordProps> = () => {
                       autoComplete="email"
                       autoFocus
                       value={values.email}
-                      onChange={handleEmailChange}
+                      onChange={handleChange}
                       onBlur={handleBlur}
                       helperText={touched.email ? errors.email : ""}
                       error={touched.email && Boolean(errors.email)}

--- a/server/__test__/account.test.ts
+++ b/server/__test__/account.test.ts
@@ -1,6 +1,8 @@
+import jwt from "jsonwebtoken";
 import accountController from "../app/controllers/account-controller";
 import accountService from "../app/services/account-service";
 import loginService from "../app/services/logins-service";
+import jwtSession from "../middleware/jwt-session";
 import { mockResponse, mockRequest, mockNext } from "./utils";
 
 jest.mock("../app/services/account-service");
@@ -773,5 +775,67 @@ describe("Account", () => {
     await accountController.updateUserProfile(req, res, next);
     expect(updateUserProfileMock).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(403);
+  });
+});
+
+// GET /api/accounts/:email must not be reachable without an authenticated staff
+// role. Previously it was public, letting anyone enumerate accounts by email and
+// harvest their id/name/confirmation/creation date (security audit finding #10).
+// These exercise the role-check middleware the route is wired with.
+describe("GET /accounts/:email authorization (finding #10)", () => {
+  const jwtSecret = process.env.JWT_SECRET || "mark it zero";
+  const guard = jwtSession.validateUserHasRequiredRoles([
+    "admin",
+    "security_admin",
+    "data_entry",
+    "global_admin",
+  ]);
+
+  const signToken = (payload: object) =>
+    jwt.sign(payload, jwtSecret, { algorithm: "HS256" });
+
+  it("rejects an unauthenticated request with 401", async () => {
+    const res = mockResponse();
+    const req = mockRequest({
+      headers: {},
+      cookies: {},
+      params: { email: "victim@test.com" },
+    });
+    const next = mockNext();
+
+    await guard(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("rejects an authenticated caller lacking a permitted role with 401", async () => {
+    const res = mockResponse();
+    const req = mockRequest({
+      headers: {},
+      cookies: { jwt: signToken({ email: "vol@test.com", sub: "coordinator" }) },
+      params: { email: "victim@test.com" },
+    });
+    const next = mockNext();
+
+    await guard(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("allows an authenticated admin through to the handler", async () => {
+    const res = mockResponse();
+    const req = mockRequest({
+      headers: {},
+      cookies: { jwt: signToken({ email: "admin@test.com", sub: "admin" }) },
+      params: { email: "someone@test.com" },
+    });
+    const next = mockNext();
+
+    await guard(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
   });
 });

--- a/server/app/routes/account-router.ts
+++ b/server/app/routes/account-router.ts
@@ -51,6 +51,22 @@ router.put(
   accountController.updateUserProfile
 );
 
-router.get("/:email", accountController.getByEmail);
+// Requires an authenticated staff role. Previously this was public, which let
+// any anonymous caller enumerate which emails have accounts (200 vs 404) and
+// harvest the account id, name, confirmation status and creation date for any
+// known email (security audit finding #10). The only legitimate caller is the
+// admin Features screen (isAdmin), which sends the jwt cookie automatically;
+// the role set mirrors GET "/" (which already exposes strictly more account
+// data to the same roles).
+router.get(
+  "/:email",
+  jwtSession.validateUserHasRequiredRoles([
+    "admin",
+    "security_admin",
+    "data_entry",
+    "global_admin",
+  ]),
+  accountController.getByEmail
+);
 
 export default router;


### PR DESCRIPTION
## Summary

`GET /api/accounts/:email` had no auth middleware, so it was reachable anonymously. A prior fix (audit finding #1) stopped it from leaking the bcrypt password hash, but the endpoint stayed public — so it could still be used to confirm whether a given email has an account (`200` vs `404`) and to read that account's `id`, name, confirmation status and creation date. This closes that gap (**security audit finding #10**).

## Changes

**Server** — [`server/app/routes/account-router.ts`](https://github.com/hackforla/food-oasis/blob/security-fix-account-email-enumeration-10/server/app/routes/account-router.ts)
- Gate the route with `jwtSession.validateUserHasRequiredRoles`, using the **same role set as `GET "/"`** (`admin`, `security_admin`, `data_entry`, `global_admin`). `GET "/"` already exposes strictly more account data to those roles, so this adds no new exposure for authenticated staff while removing all anonymous access.

**Client** — [`client/src/components/Account/ForgotPassword.tsx`](https://github.com/hackforla/food-oasis/blob/security-fix-account-email-enumeration-10/client/src/components/Account/ForgotPassword.tsx)
- Remove the per-keystroke existence check that was the only public caller. It relied on the endpoint being anonymous and is redundant — the "account not found, please register" feedback is already shown on submit via the `forgotPassword` response (`FORGOT_PASSWORD_ACCOUNT_NOT_FOUND`).
- The admin **Features** screen (`isAdmin`) is unaffected; it sends the `jwt` cookie automatically.

**Tests** — [`server/__test__/account.test.ts`](https://github.com/hackforla/food-oasis/blob/security-fix-account-email-enumeration-10/server/__test__/account.test.ts)
- Add tests asserting the route's role guard rejects an unauthenticated caller (401), rejects an authenticated caller without a permitted role (401), and lets an admin through.

## Verification
- Server `typecheck` ✅ · Server `lint` ✅ · Client `typecheck` ✅
- New finding-#10 tests: 3/3 pass. (The 10 pre-existing stale-snapshot failures in `account.test.ts` — `Object {` vs `{` pretty-format mismatch — are documented in `CLAUDE.md` §7 and unrelated to this change.)

## Note
A related but **separate** account-enumeration vector exists in the `POST /forgotPassword` flow (distinct response codes reveal account existence). It's intentionally out of scope here and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)