### PR TITLE
fix(security): CORS reflects any Origin and Allow-Credentials true

### DIFF
--- a/server/__test__/cors-middleware.test.ts
+++ b/server/__test__/cors-middleware.test.ts
@@ -1,0 +1,157 @@
+import { Request, Response } from "express";
+
+const originalCorsOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+afterEach(() => {
+  if (originalCorsOrigins === undefined) {
+    delete process.env.CORS_ALLOWED_ORIGINS;
+  } else {
+    process.env.CORS_ALLOWED_ORIGINS = originalCorsOrigins;
+  }
+  jest.resetModules();
+});
+
+// Helper to build a fresh mock req/res/next for each test
+function mockReqRes(origin: string | undefined, method = "GET") {
+  const req = {
+    headers: { origin },
+    method,
+  } as unknown as Request;
+
+  const res = {
+    setHeader: jest.fn(),
+    sendStatus: jest.fn(),
+  } as unknown as Response;
+
+  const next = jest.fn();
+
+  return { req, res, next };
+}
+
+describe("cors middleware", () => {
+  it("reflects an allowed origin and enables credentials", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://la.foodoasis.net,https://foodoasis.la";
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes("https://la.foodoasis.net");
+
+      middleware.cors(req, res, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Access-Control-Allow-Origin",
+        "https://la.foodoasis.net"
+      );
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Access-Control-Allow-Credentials",
+        "true"
+      );
+      expect(res.setHeader).toHaveBeenCalledWith("Vary", "Origin");
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  it("does not reflect an origin that is not on the allowlist", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://la.foodoasis.net";
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes("https://evil.example");
+
+      middleware.cors(req, res, next);
+
+      expect(res.setHeader).not.toHaveBeenCalledWith(
+        "Access-Control-Allow-Origin",
+        expect.anything()
+      );
+      expect(res.setHeader).not.toHaveBeenCalledWith(
+        "Access-Control-Allow-Credentials",
+        expect.anything()
+      );
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  it("does not reflect anything when the request has no Origin header", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://la.foodoasis.net";
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes(undefined);
+
+      middleware.cors(req, res, next);
+
+      expect(res.setHeader).not.toHaveBeenCalledWith(
+        "Access-Control-Allow-Origin",
+        expect.anything()
+      );
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  it("never allowlists anything when CORS_ALLOWED_ORIGINS is unset", () => {
+    delete process.env.CORS_ALLOWED_ORIGINS;
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes("https://la.foodoasis.net");
+
+      middleware.cors(req, res, next);
+
+      expect(res.setHeader).not.toHaveBeenCalledWith(
+        "Access-Control-Allow-Origin",
+        expect.anything()
+      );
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  it("always sets Allow-Methods, Max-Age, and Allow-Headers regardless of origin", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://la.foodoasis.net";
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes("https://evil.example");
+
+      middleware.cors(req, res, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Access-Control-Allow-Methods",
+        "POST, GET, PUT, DELETE, OPTIONS, XMODIFY"
+      );
+      expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Max-Age", "86400");
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Access-Control-Allow-Headers",
+        "Origin, X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept, Authorization"
+      );
+    });
+  });
+
+  it("responds 204 and does not call next() on OPTIONS requests", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://la.foodoasis.net";
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes("https://la.foodoasis.net", "OPTIONS");
+
+      middleware.cors(req, res, next);
+
+      expect(res.sendStatus).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  it("calls next() for non-OPTIONS methods", () => {
+    process.env.CORS_ALLOWED_ORIGINS = "https://la.foodoasis.net";
+
+    jest.isolateModules(() => {
+      const middleware = require("../middleware/middleware").default;
+      const { req, res, next } = mockReqRes("https://la.foodoasis.net", "POST");
+
+      middleware.cors(req, res, next);
+
+      expect(res.sendStatus).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/middleware/middleware.ts
+++ b/server/middleware/middleware.ts
@@ -1,19 +1,40 @@
 import { RequestHandler, Request, Response } from "express";
 
+// Comma-separated list of allowed frontend origins, loaded from env.
+// See server/.env.example for the expected format.
+const ALLOWED_ORIGINS = new Set(
+  (process.env.CORS_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean)
+);
+
 const cors: RequestHandler = (req, res, next): void => {
   const origin = req.headers.origin;
 
-  res.setHeader("Access-Control-Allow-Origin", origin || "*");
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    res.setHeader("Vary", "Origin"); // prevent shared-cache poisoning across origins
+  }
+  // If origin is missing or not in the allowlist, do NOT set
+  // Access-Control-Allow-Origin at all. The browser will then
+  // block the calling page from reading the response itself.
+
   res.setHeader(
     "Access-Control-Allow-Methods",
     "POST, GET, PUT, DELETE, OPTIONS, XMODIFY"
   );
-  res.setHeader("Access-Control-Allow-Credentials", "true");
   res.setHeader("Access-Control-Max-Age", "86400");
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Origin, X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept"
+    "Origin, X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept, Authorization"
   );
+
+  if (req.method === "OPTIONS") {
+    res.sendStatus(204);
+    return;
+  }
 
   next();
 };


### PR DESCRIPTION
- I propose three different versions of cors_allowed_origin as shown below, person who has access to Heroku can merge this PR after making changes?

Production

```CORS_ALLOWED_ORIGINS=https://foodoasis.la,https://foodoasis.net,https://la.foodoasis.net,https://sb.foodoasis.net,https://mck.foodoasis.net```

Development

```CORS_ALLOWED_ORIGINS=http://localhost:3000,https://foodoasis.la,https://foodoasis.net,https://la.foodoasis.net,https://sb.foodoasis.net,https://mck.foodoasis.net,https://devla.foodoasis.net```

Local

```CORS_ALLOWED_ORIGINS=http://localhost:3000,https://foodoasis.la,https://foodoasis.net,https://la.foodoasis.net,https://sb.foodoasis.net,https://mck.foodoasis.net,https://devla.foodoasis.net```

- Number 6 on the list