### PR TITLE
fix(security): add rate limiting to auth and email endpoints

### DIFF
--- a/client/src/components/Account/ConfirmEmail.tsx
+++ b/client/src/components/Account/ConfirmEmail.tsx
@@ -32,6 +32,9 @@ const ConfirmEmail = () => {
       if (result.isSuccess) {
         setView("success");
         setToast({ message: `Your email has been confirmed. Please log in.` });
+      } else if (result.code === "RATE_LIMITED") {
+        setToast({ message: result.message });
+        setView("error");
       } else {
         setView("error");
       }

--- a/client/src/components/Account/Login.tsx
+++ b/client/src/components/Account/Login.tsx
@@ -134,6 +134,13 @@ const LoginForm = () => {
                     new account.`,
                   });
                   formikBag.setSubmitting(false);
+                } else if (response?.code === "RATE_LIMITED") {
+                  setToast({
+                    message:
+                      response.message ||
+                      "Too many attempts. Please try again later.",
+                  });
+                  formikBag.setSubmitting(false);
                 } else {
                   // Presumably response.code === "AUTH_INCORRECT_PASSWORD"
                   setToast({

--- a/client/src/components/Account/Login.tsx
+++ b/client/src/components/Account/Login.tsx
@@ -111,13 +111,20 @@ const LoginForm = () => {
                   }
                 } else if (response?.code === "AUTH_NOT_CONFIRMED") {
                   try {
-                    await accountService.resendConfirmationEmail(values.email);
-                    setToast({
-                      message: `Your email has not been confirmed.
-                      Please look through your email for a Registration
-                      Confirmation link and use it to confirm that you
-                      own this email address.`,
-                    });
+                    const resendResponse =
+                      await accountService.resendConfirmationEmail(
+                        values.email
+                      );
+                    if (resendResponse.code === "RATE_LIMITED") {
+                      setToast({ message: resendResponse.message });
+                    } else {
+                      setToast({
+                        message: `Your email has not been confirmed.
+                        Please look through your email for a Registration
+                        Confirmation link and use it to confirm that you
+                        own this email address.`,
+                      });
+                    }
                     formikBag.setSubmitting(false);
                   } catch (err) {
                     setToast({

--- a/client/src/components/Account/Register.tsx
+++ b/client/src/components/Account/Register.tsx
@@ -57,6 +57,10 @@ export default function Register() {
               Please login or use the Forgot Password feature if you have
               forgotten your password.`,
           });
+        } else if (result.code === "RATE_LIMITED") {
+          setToast({
+            message: result.message,
+          });
         } else {
           setToast({
             message: `An error occurred in sending the

--- a/client/src/services/account-service.ts
+++ b/client/src/services/account-service.ts
@@ -104,6 +104,12 @@ export const login = async (
     return response.data;
   } catch (err) {
     console.error(err);
+    if (axios.isAxiosError(err) && err.response?.status === 429) {
+      // Rate-limited: surface the server's message rather than falling
+      // through to the generic "incorrect password" handling below, since
+      // this isn't a failed-credentials case.
+      return err.response.data;
+    }
     return undefined;
   }
 };

--- a/client/src/services/account-service.ts
+++ b/client/src/services/account-service.ts
@@ -54,6 +54,28 @@ export const getByEmail = async (email: string) => {
   return response;
 };
 
+// POSTs to one of the rate-limited account endpoints. On a 429, returns the
+// server's { isSuccess: false, code: "RATE_LIMITED", message } response body
+// instead of letting axios throw, so callers can handle "rate limited" the
+// same way they handle any other non-success ApiResponse (checking `code`)
+// rather than it falling into their generic network/server-error catch
+// block with a misleading message. Any other error still throws, preserving
+// each caller's existing error handling.
+const postAuthRequest = async <T extends ApiResponse>(
+  url: string,
+  body: unknown
+): Promise<T> => {
+  try {
+    const response = await axios.post(url, body);
+    return response.data;
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response?.status === 429) {
+      return err.response.data;
+    }
+    throw err;
+  }
+};
+
 export const register = async ({
   firstName,
   lastName,
@@ -61,22 +83,19 @@ export const register = async ({
   password,
 }: RegisterParams): Promise<ApiResponse> => {
   const body = { firstName, lastName, email, password, clientUrl, tenantId };
-  const response = await axios.post(baseUrl + "/register", body);
-  return response.data;
+  return postAuthRequest(baseUrl + "/register", body);
 };
 
 export const resendConfirmationEmail = async (
   email: string
 ): Promise<ApiResponse> => {
   const body = { email, clientUrl };
-  const response = await axios.post(baseUrl + "/resendConfirmationEmail", body);
-  return response.data;
+  return postAuthRequest(baseUrl + "/resendConfirmationEmail", body);
 };
 
 export const forgotPassword = async (email: string): Promise<ApiResponse> => {
   const body = { email, clientUrl };
-  const response = await axios.post(baseUrl + "/forgotPassword", body);
-  return response.data;
+  return postAuthRequest(baseUrl + "/forgotPassword", body);
 };
 
 export const resetPassword = async (
@@ -84,14 +103,12 @@ export const resetPassword = async (
   password: string
 ): Promise<ApiResponse> => {
   const body = { token, password };
-  const response = await axios.post(baseUrl + "/resetPassword", body);
-  return response.data;
+  return postAuthRequest(baseUrl + "/resetPassword", body);
 };
 
 export const confirmRegister = async (token: string): Promise<ApiResponse> => {
   const body = { token };
-  const response = await axios.post(baseUrl + "/confirmRegister", body);
-  return response.data;
+  return postAuthRequest(baseUrl + "/confirmRegister", body);
 };
 
 export const login = async (
@@ -100,16 +117,9 @@ export const login = async (
 ): Promise<ApiResponse | undefined> => {
   const body = { email, password, tenantId };
   try {
-    const response = await axios.post(baseUrl + "/login", body);
-    return response.data;
+    return await postAuthRequest(baseUrl + "/login", body);
   } catch (err) {
     console.error(err);
-    if (axios.isAxiosError(err) && err.response?.status === 429) {
-      // Rate-limited: surface the server's message rather than falling
-      // through to the generic "incorrect password" handling below, since
-      // this isn't a failed-credentials case.
-      return err.response.data;
-    }
     return undefined;
   }
 };

--- a/server/app/routes/account-router.ts
+++ b/server/app/routes/account-router.ts
@@ -2,8 +2,8 @@ import { Router } from "express";
 import accountController from "../controllers/account-controller";
 import jwtSession from "../../middleware/jwt-session";
 import {
-  strictAuthLimiter,
-  moderateAuthLimiter,
+  createStrictAuthLimiter,
+  createModerateAuthLimiter,
 } from "../../middleware/rate-limit";
 //const authenticate = require("../../middleware/authenticate");
 const router = Router();
@@ -19,26 +19,30 @@ router.get(
   accountController.getAll
 );
 
-router.post("/register", moderateAuthLimiter, accountController.register);
+router.post(
+  "/register",
+  createModerateAuthLimiter(),
+  accountController.register
+);
 router.post(
   "/resendConfirmationEmail",
-  moderateAuthLimiter,
+  createModerateAuthLimiter(),
   accountController.resendConfirmationEmail
 );
 router.post(
   "/confirmRegister",
-  moderateAuthLimiter,
+  createModerateAuthLimiter(),
   accountController.confirmRegister
 );
 
 router.post(
   "/forgotPassword",
-  strictAuthLimiter,
+  createStrictAuthLimiter(),
   accountController.forgotPassword
 );
 router.post(
   "/resetPassword",
-  strictAuthLimiter,
+  createStrictAuthLimiter(),
   accountController.resetPassword
 );
 router.post(
@@ -54,7 +58,7 @@ router.post(
 
 router.post(
   "/login",
-  strictAuthLimiter,
+  createStrictAuthLimiter(),
   accountController.login,
   jwtSession.login
 );

--- a/server/app/routes/account-router.ts
+++ b/server/app/routes/account-router.ts
@@ -1,6 +1,10 @@
 import { Router } from "express";
 import accountController from "../controllers/account-controller";
 import jwtSession from "../../middleware/jwt-session";
+import {
+  strictAuthLimiter,
+  moderateAuthLimiter,
+} from "../../middleware/rate-limit";
 //const authenticate = require("../../middleware/authenticate");
 const router = Router();
 
@@ -15,15 +19,28 @@ router.get(
   accountController.getAll
 );
 
-router.post("/register", accountController.register);
+router.post("/register", moderateAuthLimiter, accountController.register);
 router.post(
   "/resendConfirmationEmail",
+  moderateAuthLimiter,
   accountController.resendConfirmationEmail
 );
-router.post("/confirmRegister", accountController.confirmRegister);
+router.post(
+  "/confirmRegister",
+  moderateAuthLimiter,
+  accountController.confirmRegister
+);
 
-router.post("/forgotPassword", accountController.forgotPassword);
-router.post("/resetPassword", accountController.resetPassword);
+router.post(
+  "/forgotPassword",
+  strictAuthLimiter,
+  accountController.forgotPassword
+);
+router.post(
+  "/resetPassword",
+  strictAuthLimiter,
+  accountController.resetPassword
+);
 router.post(
   "/setPermissions",
   jwtSession.validateUserHasRequiredRoles(["security_admin", "global_admin"]),
@@ -35,7 +52,12 @@ router.post(
   accountController.setGlobalPermissions
 );
 
-router.post("/login", accountController.login, jwtSession.login);
+router.post(
+  "/login",
+  strictAuthLimiter,
+  accountController.login,
+  jwtSession.login
+);
 router.get("/logout", (req, res) => {
   // "Delete" cookie by expiring it immediately
   res.cookie("jwt", "", {

--- a/server/app/routes/email-router.ts
+++ b/server/app/routes/email-router.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { sendContactForm } from "../controllers/email-controller";
+import { moderateAuthLimiter } from "../../middleware/rate-limit";
 
 const router: Router = Router();
 
-router.post("/contact", sendContactForm);
+router.post("/contact", moderateAuthLimiter, sendContactForm);
 
 export default router;

--- a/server/app/routes/email-router.ts
+++ b/server/app/routes/email-router.ts
@@ -1,9 +1,9 @@
 import { Router } from "express";
 import { sendContactForm } from "../controllers/email-controller";
-import { moderateAuthLimiter } from "../../middleware/rate-limit";
+import { createModerateAuthLimiter } from "../../middleware/rate-limit";
 
 const router: Router = Router();
 
-router.post("/contact", moderateAuthLimiter, sendContactForm);
+router.post("/contact", createModerateAuthLimiter(), sendContactForm);
 
 export default router;

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -1,0 +1,35 @@
+import rateLimit from "express-rate-limit";
+
+// Rate limiting for authentication and abuse-prone endpoints (login,
+// password reset, registration, contact form) to slow down credential
+// stuffing / brute force / mass account creation / mail-relay abuse.
+//
+// Keyed by client IP (express-rate-limit's default keyGenerator). This
+// requires `app.set("trust proxy", ...)` to be configured correctly in
+// server.ts so req.ip reflects the real client address behind Heroku's
+// proxy rather than the proxy's own address.
+//
+// Uses the default in-memory store: counters are per-process and reset on
+// dyno restart/deploy, and are not shared across multiple dynos. That's an
+// acceptable first line of defense for this app's current single/low-dyno
+// deployment; a shared store (e.g. Redis) would be needed to make limits
+// hold across a horizontally-scaled deployment.
+
+// Login, forgotPassword, resetPassword: most sensitive, tightest limit.
+export const strictAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many attempts. Please try again later." },
+});
+
+// register, resendConfirmationEmail, confirmRegister, contact form:
+// less sensitive but still abuse-prone (mass account creation, mail relay).
+export const moderateAuthLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  limit: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests. Please try again later." },
+});

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -14,22 +14,37 @@ import rateLimit from "express-rate-limit";
 // acceptable first line of defense for this app's current single/low-dyno
 // deployment; a shared store (e.g. Redis) would be needed to make limits
 // hold across a horizontally-scaled deployment.
+//
+// These are factory functions, not shared instances: each rate-limited
+// route must call create*Limiter() itself and get its own limiter/store, so
+// that unrelated actions (e.g. login vs. forgotPassword) don't drain the
+// same per-IP counter as a side effect of sharing one middleware instance.
 
 // Login, forgotPassword, resetPassword: most sensitive, tightest limit.
-export const strictAuthLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  limit: 5,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many attempts. Please try again later." },
-});
+export const createStrictAuthLimiter = () =>
+  rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    limit: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      isSuccess: false,
+      code: "RATE_LIMITED",
+      message: "Too many attempts. Please try again later.",
+    },
+  });
 
 // register, resendConfirmationEmail, confirmRegister, contact form:
 // less sensitive but still abuse-prone (mass account creation, mail relay).
-export const moderateAuthLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour
-  limit: 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many requests. Please try again later." },
-});
+export const createModerateAuthLimiter = () =>
+  rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    limit: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      isSuccess: false,
+      code: "RATE_LIMITED",
+      message: "Too many requests. Please try again later.",
+    },
+  });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,6 +27,7 @@
         "dayjs": "^1.11.19",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.7.0",
         "json-2-csv": "^5.5.11",
         "jsonwebtoken": "^9.0.3",
         "massive": "^6.10.2",
@@ -11802,6 +11803,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -12671,6 +12691,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
     "dayjs": "^1.11.19",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.7.0",
     "json-2-csv": "^5.5.11",
     "jsonwebtoken": "^9.0.3",
     "massive": "^6.10.2",

--- a/server/server.ts
+++ b/server/server.ts
@@ -14,6 +14,12 @@ import { Express } from "express";
 
 const app: Express = express();
 
+// Trust the first hop proxy (Heroku's router) so req.ip / X-Forwarded-For
+// reflect the real client address rather than the proxy's. This is required
+// for IP-based rate limiting (see middleware/rate-limit.ts) to key off the
+// actual client rather than the proxy on every request.
+app.set("trust proxy", 1);
+
 // Enable compression
 app.use(compression());
 


### PR DESCRIPTION
## Problem
No `express-rate-limit` or equivalent existed anywhere in `server/`. `/api/accounts/login`, `/register`, `/forgotPassword`, `/resetPassword`, `/resendConfirmationEmail`, `/confirmRegister`, and `/api/email/contact` accepted unlimited requests, enabling credential-stuffing/brute-force against login, mass account creation, and mail-relay abuse.

## Fix
- Added `express-rate-limit` with per-IP limiting:
  - **Strict** (5 req / 15 min): `login`, `forgotPassword`, `resetPassword`
  - **Moderate** (10 req / hour): `register`, `resendConfirmationEmail`, `confirmRegister`, `email/contact`
- Each route gets its own limiter instance via a factory function (`createStrictAuthLimiter()` / `createModerateAuthLimiter()`) so unrelated actions don't share a rate-limit budget.
- Added `app.set("trust proxy", 1)` so the limiter resolves the real client IP behind Heroku's proxy rather than the proxy's own address.
- Client: `login()` now surfaces the server's actual rate-limit message on HTTP 429 instead of falling through to a misleading "incorrect password" message.
- 429 response body shape aligned with the rest of the account API's `{isSuccess, message}` convention.

## Explicitly out of scope (flagged, not silently decided)
- CAPTCHA on register/contact — needs a provider decision (reCAPTCHA/hCaptcha/Turnstile) and client integration; separate follow-up.
- Per-account (DB-tracked) lockout on login — IP-based limiting is the first line of defense here.
- Automated test coverage for the new rate limiter — accepted as a Minor by review; recommend a short follow-up so a future refactor doesn't regress the per-route isolation this PR establishes.
- Shared in-memory store (resets on dyno restart, not shared across dynos) — acceptable for the current deployment; would need Redis if horizontally scaled.

## Checks
- `npm run typecheck` (client + server): clean
- `npm run lint` (server): clean
- `npx jest --ci` (server): 10/27 failing — pre-existing stale-snapshot baseline in `account.test.ts` (unrelated to this change), no new failures
- `npm run build` (client + server): clean
- Manual verification: confirmed 429 fires at configured thresholds, confirmed per-route limiter isolation (exhausting `/login`'s budget doesn't affect `/forgotPassword`), confirmed `trust proxy` resolves real client IP and resists spoofed `X-Forwarded-For` prefixes

## Review
Independently reviewed via this repo's two-agent workflow (see `docs/agent-workflow.md`). Initial review found two Major issues (shared limiter buckets across unrelated routes; misleading 429 handling on login) — both fixed and re-verified. Final verdict: **APPROVED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)