### PR TITLE
update cookie config

### DIFF
--- a/server/middleware/jwt-session.ts
+++ b/server/middleware/jwt-session.ts
@@ -28,7 +28,7 @@ async function login(req: Request, res: Response) {
   const cookieConfig: CookieOptions = {
     httpOnly: true,
     expires: new Date(Date.now() + 86400000), // 1 day
-    sameSite: "lax",
+    sameSite: req.secure ? "none" : "lax",
     secure: req.secure ? true : false,
   };
   res.cookie("jwt", token, cookieConfig);

--- a/server/middleware/jwt-session.ts
+++ b/server/middleware/jwt-session.ts
@@ -26,9 +26,9 @@ async function login(req: Request, res: Response) {
     sub: `${req?.user?.role}` || "",
   });
   const cookieConfig: CookieOptions = {
-    httpOnly: false,
+    httpOnly: true,
     expires: new Date(Date.now() + 86400000), // 1 day
-    sameSite: req.secure ? "none" : undefined,
+    sameSite: "lax",
     secure: req.secure ? true : false,
   };
   res.cookie("jwt", token, cookieConfig);


### PR DESCRIPTION
This should be merged **after** #2873 (CORS allow-list) since sameSite: "none" cookies are only safe to send cross-origin once CORS stops reflecting arbitrary origins

- Set httpOnly: true on the JWT session cookie to prevent client-side JS or XSS from reading it via document.cookie
- Replaced sameSite: req.secure ? "none" : undefined with req.secure ? "none" : "lax" since "none" preserves cross-origin cookie auth needed for multi-tenant frontends
